### PR TITLE
Add __init__ introspection engine

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -3,6 +3,7 @@
 from importlib import metadata
 
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
+from ._inspection import DependencySpec, inspect_dependencies
 from ._qualifiers import Qualifier
 from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
 
@@ -10,12 +11,14 @@ __all__ = [
     "MISSING",
     "AsyncDisposable",
     "DependencyResolutionError",
+    "DependencySpec",
     "Disposable",
     "Factory",
     "FailureKind",
     "Qualifier",
     "ResolutionFailure",
     "Scope",
+    "inspect_dependencies",
 ]
 
 __version__ = metadata.version(__name__)

--- a/src/uncoiled/_inspection.py
+++ b/src/uncoiled/_inspection.py
@@ -1,0 +1,159 @@
+"""Introspection engine for extracting dependencies from ``__init__`` signatures."""
+
+from __future__ import annotations
+
+import inspect
+import types
+from dataclasses import dataclass
+from typing import Annotated, Union, get_args, get_origin
+
+from ._qualifiers import Qualifier
+
+
+@dataclass(frozen=True)
+class DependencySpec:
+    """A single dependency extracted from an ``__init__`` parameter."""
+
+    name: str
+    required_type: type
+    optional: bool = False
+    is_list: bool = False
+    qualifier: str | None = None
+    has_default: bool = False
+
+
+def _is_optional_union(annotation: object) -> type | None:
+    """Check if an annotation is ``T | None`` or ``Optional[T]`` and return T."""
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        args = get_args(annotation)
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1 and len(args) == 2:  # noqa: PLR2004
+            return non_none[0]
+    return None
+
+
+def inspect_dependencies(cls: type) -> list[DependencySpec]:
+    """Extract dependency specifications from a class's ``__init__`` parameters.
+
+    Inspects the ``__init__`` signature and type annotations to determine
+    what dependencies a class requires for construction.
+    """
+    try:
+        hints = inspect.get_annotations(cls.__init__, eval_str=True)
+    except Exception:  # noqa: BLE001
+        return []
+
+    sig = inspect.signature(cls.__init__)
+    specs: list[DependencySpec] = []
+
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+
+        annotation = hints.get(name)
+        if annotation is None:
+            continue
+
+        has_default = param.default is not inspect.Parameter.empty
+
+        spec = _resolve_annotation(name, annotation, has_default=has_default)
+        if spec is not None:
+            specs.append(spec)
+
+    return specs
+
+
+def _resolve_annotation(
+    name: str,
+    annotation: object,
+    *,
+    has_default: bool,
+) -> DependencySpec | None:
+    """Resolve a single annotation into a DependencySpec."""
+    origin = get_origin(annotation)
+
+    if origin is Annotated:
+        args = get_args(annotation)
+        inner = args[0]
+        qualifier = None
+        for meta in args[1:]:
+            if isinstance(meta, Qualifier):
+                qualifier = meta.name
+                break
+        return _resolve_annotation_with_qualifier(
+            name,
+            inner,
+            qualifier=qualifier,
+            has_default=has_default,
+        )
+
+    if origin is list:
+        args = get_args(annotation)
+        if args:
+            return DependencySpec(
+                name=name,
+                required_type=args[0],
+                is_list=True,
+                has_default=has_default,
+            )
+        return None
+
+    inner = _is_optional_union(annotation)
+    if inner is not None:
+        return DependencySpec(
+            name=name,
+            required_type=inner,
+            optional=True,
+            has_default=has_default,
+        )
+
+    if isinstance(annotation, type):
+        return DependencySpec(
+            name=name,
+            required_type=annotation,
+            has_default=has_default,
+        )
+
+    return None
+
+
+def _resolve_annotation_with_qualifier(
+    name: str,
+    inner: object,
+    *,
+    qualifier: str | None,
+    has_default: bool,
+) -> DependencySpec | None:
+    """Resolve inner type of an Annotated, carrying qualifier through."""
+    optional_inner = _is_optional_union(inner)
+    if optional_inner is not None:
+        return DependencySpec(
+            name=name,
+            required_type=optional_inner,
+            optional=True,
+            qualifier=qualifier,
+            has_default=has_default,
+        )
+
+    if get_origin(inner) is list:
+        args = get_args(inner)
+        if args:
+            return DependencySpec(
+                name=name,
+                required_type=args[0],
+                is_list=True,
+                qualifier=qualifier,
+                has_default=has_default,
+            )
+        return None
+
+    if isinstance(inner, type):
+        return DependencySpec(
+            name=name,
+            required_type=inner,
+            qualifier=qualifier,
+            has_default=has_default,
+        )
+
+    return None

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -1,0 +1,120 @@
+from typing import Annotated
+
+from uncoiled import DependencySpec, Qualifier, inspect_dependencies
+
+
+class Repository:
+    pass
+
+
+class UserService:
+    def __init__(self, repo: Repository) -> None:
+        self.repo = repo
+
+
+class OptionalDep:
+    def __init__(self, repo: Repository | None) -> None:
+        self.repo = repo
+
+
+class ListDep:
+    def __init__(self, repos: list[Repository]) -> None:
+        self.repos = repos
+
+
+class QualifiedDep:
+    def __init__(
+        self,
+        repo: Annotated[Repository, Qualifier("postgres")],
+    ) -> None:
+        self.repo = repo
+
+
+class DefaultDep:
+    def __init__(self, name: str = "default") -> None:
+        self.name = name
+
+
+class NoDeps:
+    pass
+
+
+class NoAnnotations:
+    def __init__(self, x) -> None:  # noqa: ANN001
+        self.x = x
+
+
+class TestInspectDependencies:
+    def test_single_dependency(self) -> None:
+        specs = inspect_dependencies(UserService)
+        assert specs == [
+            DependencySpec(name="repo", required_type=Repository),
+        ]
+
+    def test_optional_dependency(self) -> None:
+        specs = inspect_dependencies(OptionalDep)
+        assert specs == [
+            DependencySpec(
+                name="repo",
+                required_type=Repository,
+                optional=True,
+            ),
+        ]
+
+    def test_list_dependency(self) -> None:
+        specs = inspect_dependencies(ListDep)
+        assert specs == [
+            DependencySpec(
+                name="repos",
+                required_type=Repository,
+                is_list=True,
+            ),
+        ]
+
+    def test_qualified_dependency(self) -> None:
+        specs = inspect_dependencies(QualifiedDep)
+        assert specs == [
+            DependencySpec(
+                name="repo",
+                required_type=Repository,
+                qualifier="postgres",
+            ),
+        ]
+
+    def test_default_value(self) -> None:
+        specs = inspect_dependencies(DefaultDep)
+        assert specs == [
+            DependencySpec(
+                name="name",
+                required_type=str,
+                has_default=True,
+            ),
+        ]
+
+    def test_no_init(self) -> None:
+        assert inspect_dependencies(NoDeps) == []
+
+    def test_unannotated_params_skipped(self) -> None:
+        assert inspect_dependencies(NoAnnotations) == []
+
+    def test_multiple_dependencies(self) -> None:
+        class Multi:
+            def __init__(
+                self,
+                repo: Repository,
+                name: str = "x",
+                other: Repository | None = None,
+            ) -> None:
+                self.repo = repo
+                self.name = name
+                self.other = other
+
+        specs = inspect_dependencies(Multi)
+        expected = 3
+        assert len(specs) == expected
+        assert specs[0].name == "repo"
+        assert not specs[0].optional
+        assert specs[1].name == "name"
+        assert specs[1].has_default
+        assert specs[2].name == "other"
+        assert specs[2].optional


### PR DESCRIPTION
## Summary

- `DependencySpec` frozen dataclass representing a single dependency
- `inspect_dependencies(cls)` extracts specs from `__init__` type annotations
- Handles: plain `T`, `T | None`, `list[T]`, `Annotated[T, Qualifier(...)]`, defaults

## Test plan

- [x] Single, optional, list, qualified, and default dependencies
- [x] Multiple dependencies in one class
- [x] Classes with no `__init__` or unannotated params

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)