### PR TITLE
Add dependency graph builder with cycle detection

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -3,6 +3,7 @@
 from importlib import metadata
 
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
+from ._graph import ComponentNode, build_graph, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
 from ._qualifiers import Qualifier
 from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
@@ -10,6 +11,7 @@ from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
 __all__ = [
     "MISSING",
     "AsyncDisposable",
+    "ComponentNode",
     "DependencyResolutionError",
     "DependencySpec",
     "Disposable",
@@ -18,7 +20,9 @@ __all__ = [
     "Qualifier",
     "ResolutionFailure",
     "Scope",
+    "build_graph",
     "inspect_dependencies",
+    "validate_graph",
 ]
 
 __version__ = metadata.version(__name__)

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -1,0 +1,138 @@
+"""Dependency graph builder with cycle detection and validation."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+
+from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
+from ._inspection import DependencySpec, inspect_dependencies
+
+
+@dataclass
+class ComponentNode:
+    """A node in the dependency graph representing a registered component."""
+
+    impl: type
+    provides: type
+    qualifier: str | None = None
+    dependencies: list[DependencySpec] = field(default_factory=list)
+
+
+def _type_key(typ: type, qualifier: str | None = None) -> tuple[type, str | None]:
+    return (typ, qualifier)
+
+
+def build_graph(
+    registrations: dict[tuple[type, str | None], ComponentNode],
+) -> list[ResolutionFailure]:
+    """Validate the dependency graph and return any failures found.
+
+    Uses Kahn's algorithm for topological sort to detect cycles.
+    Collects all failures rather than stopping at the first.
+    """
+    failures: list[ResolutionFailure] = []
+
+    all_providers: dict[type, list[ComponentNode]] = defaultdict(list)
+    for node in registrations.values():
+        all_providers[node.provides].append(node)
+
+    adj: dict[tuple[type, str | None], set[tuple[type, str | None]]] = defaultdict(set)
+    in_degree: dict[tuple[type, str | None], int] = {}
+
+    for key in registrations:
+        in_degree.setdefault(key, 0)
+
+    for key, node in registrations.items():
+        node.dependencies = inspect_dependencies(node.impl)
+        for dep in node.dependencies:
+            dep_key = _type_key(dep.required_type, dep.qualifier)
+
+            if dep.is_list:
+                continue
+
+            if dep_key not in registrations:
+                if dep.optional or dep.has_default:
+                    continue
+                failures.append(
+                    ResolutionFailure(
+                        kind=FailureKind.MISSING,
+                        message=(
+                            f"Missing dependency for {node.impl.__name__}.__init__: "
+                            f"parameter '{dep.name}' requires type "
+                            f"'{dep.required_type.__name__}'"
+                            + (
+                                f" with qualifier '{dep.qualifier}'"
+                                if dep.qualifier
+                                else ""
+                            )
+                            + ", but no matching component is registered."
+                        ),
+                        suggestion=(
+                            f"Register a component of type "
+                            f"{dep.required_type.__name__}"
+                            + (
+                                f" with qualifier '{dep.qualifier}'"
+                                if dep.qualifier
+                                else ""
+                            )
+                            + "."
+                        ),
+                        component=node.impl,
+                        parameter=dep.name,
+                    ),
+                )
+                continue
+
+            adj[dep_key].add(key)
+            in_degree[key] = in_degree.get(key, 0) + 1
+
+    cycle_failures = _detect_cycles(registrations, adj, in_degree)
+    failures.extend(cycle_failures)
+
+    return failures
+
+
+def _detect_cycles(
+    registrations: dict[tuple[type, str | None], ComponentNode],
+    adj: dict[tuple[type, str | None], set[tuple[type, str | None]]],
+    in_degree: dict[tuple[type, str | None], int],
+) -> list[ResolutionFailure]:
+    """Use Kahn's algorithm to detect cycles in the dependency graph."""
+    queue: deque[tuple[type, str | None]] = deque()
+    for key, degree in in_degree.items():
+        if degree == 0:
+            queue.append(key)
+
+    visited = 0
+    while queue:
+        current = queue.popleft()
+        visited += 1
+        for neighbor in adj.get(current, set()):
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if visited == len(registrations):
+        return []
+
+    cycle_nodes = [key for key, degree in in_degree.items() if degree > 0]
+    cycle_names = [registrations[key].impl.__name__ for key in cycle_nodes]
+    cycle_str = " -> ".join(cycle_names)
+
+    return [
+        ResolutionFailure(
+            kind=FailureKind.CIRCULAR,
+            message=f"Circular dependency detected: {cycle_str}.",
+            suggestion=("Break the cycle by introducing an interface or factory."),
+        ),
+    ]
+
+
+def validate_graph(
+    registrations: dict[tuple[type, str | None], ComponentNode],
+) -> None:
+    """Validate the dependency graph, raising on any failures."""
+    failures = build_graph(registrations)
+    if failures:
+        raise DependencyResolutionError(failures)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+from uncoiled import (
+    ComponentNode,
+    DependencyResolutionError,
+    FailureKind,
+    build_graph,
+    validate_graph,
+)
+
+
+def _make_registrations(
+    *nodes: ComponentNode,
+) -> dict[tuple[type, str | None], ComponentNode]:
+    return {(node.provides, node.qualifier): node for node in nodes}
+
+
+class Repository:
+    pass
+
+
+class UserService:
+    def __init__(self, repo: Repository) -> None:
+        self.repo = repo
+
+
+class CycleA:
+    def __init__(self, b: CycleB) -> None:
+        self.b = b
+
+
+class CycleB:
+    def __init__(self, a: CycleA) -> None:
+        self.a = a
+
+
+class TestBuildGraph:
+    def test_valid_graph_no_failures(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=Repository, provides=Repository),
+            ComponentNode(impl=UserService, provides=UserService),
+        )
+        failures = build_graph(registrations)
+        assert failures == []
+
+    def test_missing_dependency(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=UserService, provides=UserService),
+        )
+        failures = build_graph(registrations)
+        assert len(failures) == 1
+        assert failures[0].kind is FailureKind.MISSING
+        assert "Repository" in failures[0].message
+        assert failures[0].component is UserService
+        assert failures[0].parameter == "repo"
+
+    def test_optional_dependency_not_required(self) -> None:
+        class OptService:
+            def __init__(self, repo: Repository | None = None) -> None:
+                self.repo = repo
+
+        registrations = _make_registrations(
+            ComponentNode(impl=OptService, provides=OptService),
+        )
+        assert build_graph(registrations) == []
+
+    def test_default_dependency_not_required(self) -> None:
+        class DefaultService:
+            def __init__(self, name: str = "default") -> None:
+                self.name = name
+
+        registrations = _make_registrations(
+            ComponentNode(impl=DefaultService, provides=DefaultService),
+        )
+        assert build_graph(registrations) == []
+
+    def test_circular_dependency(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=CycleA, provides=CycleA),
+            ComponentNode(impl=CycleB, provides=CycleB),
+        )
+        failures = build_graph(registrations)
+        assert any(f.kind is FailureKind.CIRCULAR for f in failures)
+
+    def test_list_dependency_not_required(self) -> None:
+        class MultiService:
+            def __init__(self, repos: list[Repository]) -> None:
+                self.repos = repos
+
+        registrations = _make_registrations(
+            ComponentNode(impl=MultiService, provides=MultiService),
+        )
+        assert build_graph(registrations) == []
+
+    def test_multiple_failures_collected(self) -> None:
+        class NeedsBoth:
+            def __init__(self, a: Repository, b: UserService) -> None:
+                self.a = a
+                self.b = b
+
+        registrations = _make_registrations(
+            ComponentNode(impl=NeedsBoth, provides=NeedsBoth),
+        )
+        failures = build_graph(registrations)
+        expected = 2
+        assert len(failures) == expected
+
+
+class TestValidateGraph:
+    def test_raises_on_failure(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=UserService, provides=UserService),
+        )
+        with pytest.raises(DependencyResolutionError) as exc_info:
+            validate_graph(registrations)
+        assert len(exc_info.value.failures) == 1
+
+    def test_passes_valid_graph(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=Repository, provides=Repository),
+            ComponentNode(impl=UserService, provides=UserService),
+        )
+        validate_graph(registrations)


### PR DESCRIPTION
## Summary

- `ComponentNode` dataclass representing a registered component in the graph
- `build_graph()` validates the dependency graph using Kahn's algorithm for topological sort
- Detects missing dependencies, circular dependencies, and collects all failures
- `validate_graph()` convenience function that raises `DependencyResolutionError`

Depends on #24

## Test plan

- [x] Valid graph produces no failures
- [x] Missing, circular, and multiple failures detected
- [x] Optional and default dependencies don't produce failures
- [x] List dependencies don't require registration
- [x] `validate_graph` raises on invalid graphs

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)