### PR TITLE
Add @component decorator and ComponentMetadata

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib import metadata
 
+from ._component import ComponentMetadata, component
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
@@ -11,6 +12,7 @@ from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
 __all__ = [
     "MISSING",
     "AsyncDisposable",
+    "ComponentMetadata",
     "ComponentNode",
     "DependencyResolutionError",
     "DependencySpec",
@@ -21,6 +23,7 @@ __all__ = [
     "ResolutionFailure",
     "Scope",
     "build_graph",
+    "component",
     "inspect_dependencies",
     "validate_graph",
 ]

--- a/src/uncoiled/_component.py
+++ b/src/uncoiled/_component.py
@@ -1,0 +1,68 @@
+"""``@component`` decorator for marking DI-managed classes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import overload
+
+from ._types import Scope
+
+
+@dataclass(frozen=True)
+class ComponentMetadata:
+    """Metadata attached to a class by the ``@component`` decorator."""
+
+    scope: Scope = Scope.SINGLETON
+    qualifier: str | None = None
+
+
+@overload
+def component(cls: type, /) -> type: ...
+
+
+@overload
+def component(
+    *,
+    scope: Scope = ...,
+    qualifier: str | None = ...,
+) -> _ComponentDecorator: ...
+
+
+def component(
+    cls: type | None = None,
+    /,
+    *,
+    scope: Scope = Scope.SINGLETON,
+    qualifier: str | None = None,
+) -> type | _ComponentDecorator:
+    """Mark a class as a DI-managed component.
+
+    Can be used with or without arguments::
+
+        @component
+        class UserService: ...
+
+        @component(scope=Scope.TRANSIENT, qualifier="special")
+        class SpecialService: ...
+
+    Attaches ``ComponentMetadata`` as a ``__uncoiled__`` attribute.
+    Does not modify class behaviour.
+    """
+    meta = ComponentMetadata(scope=scope, qualifier=qualifier)
+
+    if cls is not None:
+        cls.__uncoiled__ = meta  # type: ignore[attr-defined]
+        return cls
+
+    return _ComponentDecorator(meta)
+
+
+class _ComponentDecorator:
+    """Callable returned by ``@component(...)`` with arguments."""
+
+    def __init__(self, meta: ComponentMetadata) -> None:
+        self._meta = meta
+
+    def __call__(self, cls: type) -> type:
+        cls.__uncoiled__ = self._meta  # type: ignore[attr-defined]
+        return cls

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,0 +1,65 @@
+from uncoiled import ComponentMetadata, Scope, component
+
+
+def _get_metadata(cls: type) -> ComponentMetadata:
+    return cls.__uncoiled__  # type: ignore[attr-defined]
+
+
+class TestComponentDecorator:
+    def test_bare_decorator(self) -> None:
+        @component
+        class MyService:
+            pass
+
+        assert hasattr(MyService, "__uncoiled__")
+        assert _get_metadata(MyService) == ComponentMetadata()
+
+    def test_decorator_with_scope(self) -> None:
+        @component(scope=Scope.TRANSIENT)
+        class MyService:
+            pass
+
+        assert _get_metadata(MyService).scope is Scope.TRANSIENT
+
+    def test_decorator_with_qualifier(self) -> None:
+        @component(qualifier="special")
+        class MyService:
+            pass
+
+        assert _get_metadata(MyService).qualifier == "special"
+
+    def test_decorator_with_all_options(self) -> None:
+        @component(scope=Scope.TRANSIENT, qualifier="special")
+        class MyService:
+            pass
+
+        expected = ComponentMetadata(
+            scope=Scope.TRANSIENT,
+            qualifier="special",
+        )
+        assert _get_metadata(MyService) == expected
+
+    def test_does_not_modify_class(self) -> None:
+        @component
+        class MyService:
+            def greet(self) -> str:
+                return "hello"
+
+        assert MyService().greet() == "hello"
+
+    def test_default_scope_is_singleton(self) -> None:
+        @component
+        class MyService:
+            pass
+
+        assert _get_metadata(MyService).scope is Scope.SINGLETON
+
+    def test_metadata_is_frozen(self) -> None:
+        meta = ComponentMetadata()
+        try:
+            meta.scope = Scope.TRANSIENT  # type: ignore[misc]
+        except AttributeError:
+            pass
+        else:
+            msg = "Expected frozen dataclass to reject mutation"
+            raise AssertionError(msg)


### PR DESCRIPTION
## Summary

- `@component` decorator (works with and without arguments)
- `ComponentMetadata` frozen dataclass attached as `__uncoiled__` attribute
- Purely a marker — does not modify class behaviour

Depends on #25

## Test plan

- [x] Bare `@component` and `@component(scope=..., qualifier=...)` variants
- [x] Default scope is SINGLETON
- [x] Class behaviour unmodified
- [x] Metadata is frozen

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)