### PR TITLE
Add scope managers

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -7,6 +7,7 @@ from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
 from ._qualifiers import Qualifier
+from ._scope import ScopeManager, SingletonScope, TransientScope
 from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
 
 __all__ = [
@@ -22,6 +23,9 @@ __all__ = [
     "Qualifier",
     "ResolutionFailure",
     "Scope",
+    "ScopeManager",
+    "SingletonScope",
+    "TransientScope",
     "build_graph",
     "component",
     "inspect_dependencies",

--- a/src/uncoiled/_scope.py
+++ b/src/uncoiled/_scope.py
@@ -1,0 +1,72 @@
+"""Scope managers controlling component lifecycle."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ._types import Scope
+
+
+@runtime_checkable
+class ScopeManager(Protocol):
+    """Protocol for custom scope implementations."""
+
+    @property
+    def scope(self) -> Scope:
+        """Return the scope this manager handles."""
+        ...
+
+    def get[T](self, key: type[T]) -> T | None:
+        """Return a cached instance or None."""
+        ...
+
+    def put[T](self, key: type[T], instance: T) -> None:
+        """Store an instance in this scope."""
+        ...
+
+    def clear(self) -> None:
+        """Remove all instances from this scope."""
+        ...
+
+
+class SingletonScope:
+    """Scope that caches a single instance per type for the container's lifetime."""
+
+    def __init__(self) -> None:
+        self._instances: dict[type, object] = {}
+
+    @property
+    def scope(self) -> Scope:
+        """Return the scope type."""
+        return Scope.SINGLETON
+
+    def get[T](self, key: type[T]) -> T | None:
+        """Return the cached instance or None."""
+        return self._instances.get(key)  # type: ignore[return-value]
+
+    def put[T](self, key: type[T], instance: T) -> None:
+        """Cache the instance."""
+        self._instances[key] = instance
+
+    def clear(self) -> None:
+        """Remove all cached instances."""
+        self._instances.clear()
+
+
+class TransientScope:
+    """Scope that never caches — creates a new instance on every resolution."""
+
+    @property
+    def scope(self) -> Scope:
+        """Return the scope type."""
+        return Scope.TRANSIENT
+
+    def get[T](self, key: type[T]) -> T | None:  # noqa: ARG002
+        """Return None; transient instances are never cached."""
+        return None
+
+    def put[T](self, key: type[T], instance: T) -> None:
+        """Do nothing; transient instances are not cached."""
+
+    def clear(self) -> None:
+        """No-op (nothing to clear)."""

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,47 @@
+from uncoiled import Scope, ScopeManager, SingletonScope, TransientScope
+
+
+class TestSingletonScope:
+    def test_scope_type(self) -> None:
+        assert SingletonScope().scope is Scope.SINGLETON
+
+    def test_get_returns_none_when_empty(self) -> None:
+        scope = SingletonScope()
+        assert scope.get(str) is None
+
+    def test_put_and_get(self) -> None:
+        scope = SingletonScope()
+        scope.put(str, "hello")
+        assert scope.get(str) == "hello"
+
+    def test_returns_same_instance(self) -> None:
+        scope = SingletonScope()
+        obj = object()
+        scope.put(object, obj)
+        assert scope.get(object) is obj
+
+    def test_clear(self) -> None:
+        scope = SingletonScope()
+        scope.put(str, "hello")
+        scope.clear()
+        assert scope.get(str) is None
+
+    def test_conforms_to_protocol(self) -> None:
+        assert isinstance(SingletonScope(), ScopeManager)
+
+
+class TestTransientScope:
+    def test_scope_type(self) -> None:
+        assert TransientScope().scope is Scope.TRANSIENT
+
+    def test_get_always_returns_none(self) -> None:
+        scope = TransientScope()
+        scope.put(str, "hello")
+        assert scope.get(str) is None
+
+    def test_clear_is_noop(self) -> None:
+        scope = TransientScope()
+        scope.clear()
+
+    def test_conforms_to_protocol(self) -> None:
+        assert isinstance(TransientScope(), ScopeManager)


### PR DESCRIPTION
## Summary

- `ScopeManager` runtime-checkable protocol for custom scopes
- `SingletonScope` — caches one instance per type
- `TransientScope` — never caches, always creates new

Depends on #25, #26

## Test plan

- [x] Singleton put/get/clear lifecycle
- [x] Transient always returns None
- [x] Both conform to ScopeManager protocol

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)