### PR TITLE
Add lifecycle hook management

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -6,6 +6,7 @@ from ._component import ComponentMetadata, component
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
+from ._lifecycle import async_call_destroy, async_call_init, call_destroy, call_init
 from ._qualifiers import Qualifier
 from ._scope import ScopeManager, SingletonScope, TransientScope
 from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
@@ -26,7 +27,11 @@ __all__ = [
     "ScopeManager",
     "SingletonScope",
     "TransientScope",
+    "async_call_destroy",
+    "async_call_init",
     "build_graph",
+    "call_destroy",
+    "call_init",
     "component",
     "inspect_dependencies",
     "validate_graph",

--- a/src/uncoiled/_lifecycle.py
+++ b/src/uncoiled/_lifecycle.py
@@ -1,0 +1,55 @@
+"""Init/destroy hook management for component lifecycle."""
+
+from __future__ import annotations
+
+from ._types import AsyncDisposable, Disposable
+
+
+def call_init(instance: object, init_method: str | None = None) -> None:
+    """Call the init hook on an instance if applicable."""
+    if init_method is not None:
+        method = getattr(instance, init_method)
+        method()
+
+
+async def async_call_init(
+    instance: object,
+    init_method: str | None = None,
+) -> None:
+    """Call the init hook on an instance, supporting async methods."""
+    if init_method is not None:
+        method = getattr(instance, init_method)
+        result = method()
+        if hasattr(result, "__await__"):
+            await result
+
+
+def call_destroy(instance: object, destroy_method: str | None = None) -> None:
+    """Call the destroy hook on an instance if applicable.
+
+    Checks explicit destroy_method first, then Disposable protocol.
+    """
+    if destroy_method is not None:
+        method = getattr(instance, destroy_method)
+        method()
+    elif isinstance(instance, Disposable):
+        instance.close()
+
+
+async def async_call_destroy(
+    instance: object,
+    destroy_method: str | None = None,
+) -> None:
+    """Call the destroy hook on an instance, supporting async methods.
+
+    Check explicit destroy_method first, then AsyncDisposable, then Disposable.
+    """
+    if destroy_method is not None:
+        method = getattr(instance, destroy_method)
+        result = method()
+        if hasattr(result, "__await__"):
+            await result
+    elif isinstance(instance, AsyncDisposable):
+        await instance.aclose()
+    elif isinstance(instance, Disposable):
+        instance.close()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,110 @@
+import asyncio
+
+from uncoiled import async_call_destroy, async_call_init, call_destroy, call_init
+
+
+class TestCallInit:
+    def test_calls_named_method(self) -> None:
+        class Service:
+            started = False
+
+            def start(self) -> None:
+                self.started = True
+
+        svc = Service()
+        call_init(svc, "start")
+        assert svc.started
+
+    def test_noop_when_no_method(self) -> None:
+        call_init(object())
+
+
+class TestCallDestroy:
+    def test_calls_named_method(self) -> None:
+        class Service:
+            stopped = False
+
+            def stop(self) -> None:
+                self.stopped = True
+
+        svc = Service()
+        call_destroy(svc, "stop")
+        assert svc.stopped
+
+    def test_calls_close_on_disposable(self) -> None:
+        class Resource:
+            closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        res = Resource()
+        call_destroy(res)
+        assert res.closed
+
+    def test_explicit_method_takes_priority(self) -> None:
+        class Resource:
+            closed = False
+            stopped = False
+
+            def close(self) -> None:
+                self.closed = True
+
+            def stop(self) -> None:
+                self.stopped = True
+
+        res = Resource()
+        call_destroy(res, "stop")
+        assert res.stopped
+        assert not res.closed
+
+    def test_noop_when_no_method(self) -> None:
+        call_destroy(object())
+
+
+class TestAsyncCallInit:
+    def test_calls_async_init(self) -> None:
+        class Service:
+            started = False
+
+            async def start(self) -> None:
+                self.started = True
+
+        svc = Service()
+        asyncio.run(async_call_init(svc, "start"))
+        assert svc.started
+
+    def test_calls_sync_init(self) -> None:
+        class Service:
+            started = False
+
+            def start(self) -> None:
+                self.started = True
+
+        svc = Service()
+        asyncio.run(async_call_init(svc, "start"))
+        assert svc.started
+
+
+class TestAsyncCallDestroy:
+    def test_calls_async_aclose(self) -> None:
+        class Resource:
+            closed = False
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        res = Resource()
+        asyncio.run(async_call_destroy(res))
+        assert res.closed
+
+    def test_falls_back_to_sync_close(self) -> None:
+        class Resource:
+            closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        res = Resource()
+        asyncio.run(async_call_destroy(res))
+        assert res.closed


### PR DESCRIPTION
## Summary

- `call_init` / `async_call_init` — call named init methods (sync/async)
- `call_destroy` / `async_call_destroy` — call named destroy methods, fall back to Disposable/AsyncDisposable protocols

Depends on #27

## Test plan

- [x] Named init/destroy methods
- [x] Disposable protocol auto-detection
- [x] AsyncDisposable with fallback to sync close
- [x] No-op when no hooks configured

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)