### PR TITLE
Add Container class — central DI runtime

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -3,6 +3,7 @@
 from importlib import metadata
 
 from ._component import ComponentMetadata, component
+from ._container import Container
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
@@ -16,6 +17,7 @@ __all__ = [
     "AsyncDisposable",
     "ComponentMetadata",
     "ComponentNode",
+    "Container",
     "DependencyResolutionError",
     "DependencySpec",
     "Disposable",

--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -1,0 +1,223 @@
+"""Container class — the central dependency injection runtime."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import TYPE_CHECKING, Self
+
+from ._graph import ComponentNode, validate_graph
+from ._inspection import DependencySpec, inspect_dependencies
+from ._lifecycle import call_destroy, call_init
+from ._scope import SingletonScope, TransientScope
+from ._types import Scope
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from ._component import ComponentMetadata
+    from ._scope import ScopeManager
+
+
+class Container:
+    """Central dependency injection container.
+
+    Manage component registration, validation, lifecycle, and resolution.
+    """
+
+    def __init__(self) -> None:
+        self._registrations: dict[tuple[type, str | None], ComponentNode] = {}
+        self._scopes: dict[Scope, ScopeManager] = {
+            Scope.SINGLETON: SingletonScope(),
+            Scope.TRANSIENT: TransientScope(),
+        }
+        self._instances: list[object] = []
+        self._destroy_hooks: dict[type, str | None] = {}
+        self._init_hooks: dict[type, str | None] = {}
+        self._started = False
+
+    def register(  # noqa: PLR0913
+        self,
+        cls: type,
+        *,
+        scope: Scope = Scope.SINGLETON,
+        qualifier: str | None = None,
+        provides: type | None = None,
+        init_method: str | None = None,
+        destroy_method: str | None = None,
+    ) -> None:
+        """Register a class as a component."""
+        provides = provides or cls
+        key = (provides, qualifier)
+        self._registrations[key] = ComponentNode(
+            impl=cls,
+            provides=provides,
+            qualifier=qualifier,
+            scope=scope,
+        )
+        self._registrations[key].dependencies = inspect_dependencies(cls)
+        if init_method:
+            self._init_hooks[cls] = init_method
+        if destroy_method:
+            self._destroy_hooks[cls] = destroy_method
+
+    def register_instance(
+        self,
+        instance: object,
+        *,
+        type_: type | None = None,
+        qualifier: str | None = None,
+    ) -> None:
+        """Register a pre-constructed instance."""
+        type_ = type_ or type(instance)
+        key = (type_, qualifier)
+        self._registrations[key] = ComponentNode(
+            impl=type_,
+            provides=type_,
+            qualifier=qualifier,
+        )
+        self._scopes[Scope.SINGLETON].put(type_, instance)
+
+    def register_factory(
+        self,
+        factory: object,
+        *,
+        return_type: type,
+        scope: Scope = Scope.SINGLETON,
+        qualifier: str | None = None,
+    ) -> None:
+        """Register a factory callable for a type."""
+        key = (return_type, qualifier)
+        self._registrations[key] = ComponentNode(
+            impl=return_type,
+            provides=return_type,
+            qualifier=qualifier,
+            scope=scope,
+            factory=factory,
+        )
+
+    def scan(self, *modules: str | ModuleType) -> None:
+        """Scan modules for ``@component``-decorated classes and register them."""
+        for module in modules:
+            if isinstance(module, str):
+                module = importlib.import_module(module)  # noqa: PLW2901
+            self._scan_module(module)
+
+    def _scan_module(self, mod: ModuleType) -> None:
+        """Scan a single module and its submodules for components."""
+        for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            meta: ComponentMetadata | None = getattr(obj, "__uncoiled__", None)
+            if meta is not None:
+                self.register(obj, scope=meta.scope, qualifier=meta.qualifier)
+
+        if hasattr(mod, "__path__"):
+            for _importer, modname, _ispkg in pkgutil.walk_packages(
+                mod.__path__,
+                prefix=mod.__name__ + ".",
+            ):
+                submod = importlib.import_module(modname)
+                self._scan_module(submod)
+
+    def validate(self) -> None:
+        """Validate the dependency graph eagerly."""
+        validate_graph(self._registrations)
+
+    def start(self) -> None:
+        """Validate the graph and instantiate all singletons."""
+        self.validate()
+        singleton = self._scopes[Scope.SINGLETON]
+        for key, node in self._registrations.items():
+            if node.scope is Scope.SINGLETON and singleton.get(node.provides) is None:
+                self._resolve(node.provides, key[1])
+        self._started = True
+
+    def close(self) -> None:
+        """Destroy instances in reverse creation order."""
+        for instance in reversed(self._instances):
+            destroy_method = self._destroy_hooks.get(type(instance))
+            call_destroy(instance, destroy_method)
+        self._instances.clear()
+        for scope_manager in self._scopes.values():
+            scope_manager.clear()
+        self._started = False
+
+    def get[T](self, type_: type[T], qualifier: str | None = None) -> T:
+        """Resolve a single instance of the given type."""
+        return self._resolve(type_, qualifier)
+
+    def get_all[T](self, type_: type[T]) -> list[T]:
+        """Resolve all registered implementations of the given type."""
+        results: list[T] = []
+        for (reg_type, qual), node in self._registrations.items():
+            if reg_type is type_ or (
+                isinstance(reg_type, type) and issubclass(reg_type, type_)
+            ):
+                results.append(self._resolve(node.provides, qual))  # type: ignore[arg-type]
+        return results
+
+    def _resolve[T](self, type_: type[T], qualifier: str | None = None) -> T:
+        """Resolve a type from the container."""
+        key = (type_, qualifier)
+        node = self._registrations.get(key)
+        if node is None:
+            msg = f"No component registered for type {type_.__name__}"
+            if qualifier:
+                msg += f" with qualifier '{qualifier}'"
+            raise LookupError(msg)
+
+        scope_manager = self._scopes.get(node.scope)
+        if scope_manager:
+            cached = scope_manager.get(type_)
+            if cached is not None:
+                return cached
+
+        instance = self._create_instance(node)
+
+        if scope_manager:
+            scope_manager.put(type_, instance)
+
+        self._instances.append(instance)
+        call_init(instance, self._init_hooks.get(node.impl))
+
+        return instance  # type: ignore[return-value]
+
+    def _create_instance(self, node: ComponentNode) -> object:
+        """Create an instance from a ComponentNode."""
+        if node.factory is not None:
+            return node.factory()  # type: ignore[operator]
+
+        deps = inspect_dependencies(node.impl)
+        kwargs: dict[str, object] = {}
+        for dep in deps:
+            self._resolve_dependency(dep, kwargs)
+        return node.impl(**kwargs)
+
+    def _resolve_dependency(
+        self,
+        dep: DependencySpec,
+        kwargs: dict[str, object],
+    ) -> None:
+        """Resolve a single dependency into kwargs."""
+        if dep.is_list:
+            kwargs[dep.name] = self.get_all(dep.required_type)
+        elif dep.optional or dep.has_default:
+            dep_key = (dep.required_type, dep.qualifier)
+            if dep_key in self._registrations:
+                kwargs[dep.name] = self._resolve(
+                    dep.required_type,
+                    dep.qualifier,
+                )
+            elif dep.optional:
+                kwargs[dep.name] = None
+        else:
+            kwargs[dep.name] = self._resolve(dep.required_type, dep.qualifier)
+
+    def __enter__(self) -> Self:
+        """Start the container as a context manager."""
+        self.start()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        """Close the container."""
+        self.close()

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._inspection import DependencySpec, inspect_dependencies
+from ._types import Scope
 
 
 @dataclass
@@ -17,6 +18,8 @@ class ComponentNode:
     provides: type
     qualifier: str | None = None
     dependencies: list[DependencySpec] = field(default_factory=list)
+    scope: Scope = Scope.SINGLETON
+    factory: object | None = None
 
 
 def _type_key(typ: type, qualifier: str | None = None) -> tuple[type, str | None]:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,186 @@
+import types
+
+import pytest
+
+from uncoiled import Container, DependencyResolutionError, Scope, component
+
+
+class Repository:
+    pass
+
+
+class UserService:
+    def __init__(self, repo: Repository) -> None:
+        self.repo = repo
+
+
+class TestContainerRegistration:
+    def test_register_and_get(self) -> None:
+        c = Container()
+        c.register(Repository)
+        assert isinstance(c.get(Repository), Repository)
+
+    def test_register_with_qualifier(self) -> None:
+        c = Container()
+        c.register(Repository, qualifier="primary")
+        assert isinstance(c.get(Repository, qualifier="primary"), Repository)
+
+    def test_register_instance(self) -> None:
+        repo = Repository()
+        c = Container()
+        c.register_instance(repo)
+        assert c.get(Repository) is repo
+
+    def test_register_factory(self) -> None:
+        c = Container()
+        c.register_factory(Repository, return_type=Repository)
+        assert isinstance(c.get(Repository), Repository)
+
+
+class TestContainerResolution:
+    def test_singleton_scope(self) -> None:
+        c = Container()
+        c.register(Repository)
+        first = c.get(Repository)
+        second = c.get(Repository)
+        assert first is second
+
+    def test_transient_scope(self) -> None:
+        c = Container()
+        c.register(Repository, scope=Scope.TRANSIENT)
+        first = c.get(Repository)
+        second = c.get(Repository)
+        assert first is not second
+
+    def test_dependency_injection(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.register(UserService)
+        svc = c.get(UserService)
+        assert isinstance(svc.repo, Repository)
+
+    def test_optional_dependency_none(self) -> None:
+        class OptService:
+            def __init__(self, repo: Repository | None = None) -> None:
+                self.repo = repo
+
+        c = Container()
+        c.register(OptService)
+        assert c.get(OptService).repo is None
+
+    def test_optional_dependency_present(self) -> None:
+        class OptService:
+            def __init__(self, repo: Repository | None = None) -> None:
+                self.repo = repo
+
+        c = Container()
+        c.register(Repository)
+        c.register(OptService)
+        assert isinstance(c.get(OptService).repo, Repository)
+
+    def test_list_dependency(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        class RepoB(Repository):
+            pass
+
+        class MultiService:
+            def __init__(self, repos: list[Repository]) -> None:
+                self.repos = repos
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="a")
+        c.register(RepoB, provides=Repository, qualifier="b")
+        c.register(MultiService)
+        svc = c.get(MultiService)
+        expected_count = 2
+        assert len(svc.repos) == expected_count
+
+    def test_missing_dependency_raises(self) -> None:
+        c = Container()
+        with pytest.raises(LookupError, match="UserService"):
+            c.get(UserService)
+
+    def test_get_all(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        class RepoB(Repository):
+            pass
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="a")
+        c.register(RepoB, provides=Repository, qualifier="b")
+        results = c.get_all(Repository)
+        expected_count = 2
+        assert len(results) == expected_count
+
+
+class TestContainerValidation:
+    def test_validate_raises_on_missing(self) -> None:
+        c = Container()
+        c.register(UserService)
+        with pytest.raises(DependencyResolutionError):
+            c.validate()
+
+    def test_validate_passes_valid(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.register(UserService)
+        c.validate()
+
+
+class TestContainerLifecycle:
+    def test_start_instantiates_singletons(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.start()
+        assert c.get(Repository) is not None
+
+    def test_close_calls_destroy(self) -> None:
+        class Resource:
+            closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        c = Container()
+        c.register(Resource)
+        c.start()
+        res = c.get(Resource)
+        c.close()
+        assert res.closed
+
+    def test_init_method(self) -> None:
+        class Service:
+            started = False
+
+            def start(self) -> None:
+                self.started = True
+
+        c = Container()
+        c.register(Service, init_method="start")
+        svc = c.get(Service)
+        assert svc.started
+
+    def test_context_manager(self) -> None:
+        c = Container()
+        c.register(Repository)
+        with c:
+            repo = c.get(Repository)
+            assert isinstance(repo, Repository)
+
+
+class TestContainerScan:
+    def test_scan_finds_decorated_classes(self) -> None:
+        @component
+        class ScanService:
+            pass
+
+        mod = types.ModuleType("test_scan_mod")
+        mod.ScanService = ScanService  # type: ignore[attr-defined]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(ScanService), ScanService)


### PR DESCRIPTION
## Summary

- `Container` class with registration (`register`, `register_instance`, `register_factory`, `scan`)
- Validation via `validate()` and `start()` (fail-fast)
- Resolution via `get(type_)` and `get_all(type_)` with automatic dependency injection
- Singleton and transient scope support
- Init/destroy lifecycle hooks
- Context manager support (`with Container()`)
- Adds `scope` and `factory` fields to `ComponentNode`

## Test plan

- [x] Register and resolve by type, qualifier, instance, factory
- [x] Singleton returns same instance, transient creates new
- [x] Automatic constructor injection
- [x] Optional deps resolve to None when unregistered
- [x] List deps collect all implementations
- [x] Missing dependency raises LookupError
- [x] Validation raises DependencyResolutionError
- [x] Start instantiates singletons, close calls destroy hooks
- [x] Init method called on creation
- [x] Context manager lifecycle
- [x] Module scanning finds @component classes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)