### PR TITLE
Add relaxed binding name normalisation

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -3,6 +3,7 @@
 from importlib import metadata
 
 from ._component import ComponentMetadata, component
+from ._config._relaxed import normalise
 from ._container import Container
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
@@ -36,6 +37,7 @@ __all__ = [
     "call_init",
     "component",
     "inspect_dependencies",
+    "normalise",
     "validate_graph",
 ]
 

--- a/src/uncoiled/_config/__init__.py
+++ b/src/uncoiled/_config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration subsystem for uncoiled."""

--- a/src/uncoiled/_config/_relaxed.py
+++ b/src/uncoiled/_config/_relaxed.py
@@ -1,0 +1,19 @@
+"""Relaxed binding name normalisation for configuration keys.
+
+Normalises different naming conventions to a canonical dotted form:
+
+- ``MY_DB_HOST`` → ``my.db.host``
+- ``my-db-host`` → ``my.db.host``
+- ``my.db.host`` → ``my.db.host``
+"""
+
+from __future__ import annotations
+
+import re
+
+_SEPARATOR_RE = re.compile(r"[-_.]")
+
+
+def normalise(key: str) -> str:
+    """Normalise a configuration key to canonical dotted lowercase form."""
+    return _SEPARATOR_RE.sub(".", key).lower()

--- a/tests/test_relaxed.py
+++ b/tests/test_relaxed.py
@@ -1,0 +1,19 @@
+import pytest
+
+from uncoiled import normalise
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("MY_DB_HOST", "my.db.host"),
+        ("my-db-host", "my.db.host"),
+        ("my.db.host", "my.db.host"),
+        ("MY-DB_HOST", "my.db.host"),
+        ("simple", "simple"),
+        ("UPPER", "upper"),
+        ("a.b-c_d", "a.b.c.d"),
+    ],
+)
+def test_normalise(key: str, expected: str) -> None:
+    assert normalise(key) == expected


### PR DESCRIPTION
## Summary

- `normalise()` function converts config keys to canonical dotted lowercase form
- `MY_DB_HOST`, `my-db-host`, `my.db.host` all normalise to `my.db.host`
- Creates `_config` subpackage

## Test plan

- [x] Parametrized tests for underscore, hyphen, dot, mixed, and simple keys

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)