### PR TITLE
Add config sources: Dict, Env, DotEnv, Layered

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -4,6 +4,13 @@ from importlib import metadata
 
 from ._component import ComponentMetadata, component
 from ._config._relaxed import normalise
+from ._config._sources import (
+    ConfigSource,
+    DictSource,
+    DotEnvSource,
+    EnvSource,
+    LayeredSource,
+)
 from ._container import Container
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
@@ -18,12 +25,17 @@ __all__ = [
     "AsyncDisposable",
     "ComponentMetadata",
     "ComponentNode",
+    "ConfigSource",
     "Container",
     "DependencyResolutionError",
     "DependencySpec",
+    "DictSource",
     "Disposable",
+    "DotEnvSource",
+    "EnvSource",
     "Factory",
     "FailureKind",
+    "LayeredSource",
     "Qualifier",
     "ResolutionFailure",
     "Scope",

--- a/src/uncoiled/_config/_sources.py
+++ b/src/uncoiled/_config/_sources.py
@@ -1,0 +1,87 @@
+"""Configuration sources with layered precedence."""
+
+from __future__ import annotations
+
+import os
+from typing import Protocol, runtime_checkable
+
+from ._relaxed import normalise
+
+
+@runtime_checkable
+class ConfigSource(Protocol):
+    """Protocol for configuration value sources."""
+
+    def get(self, key: str) -> str | None:
+        """Return the value for the given key, or None if not found."""
+        ...
+
+
+class DictSource:
+    """Configuration source backed by a plain dictionary."""
+
+    def __init__(self, data: dict[str, str]) -> None:
+        self._data = {normalise(k): v for k, v in data.items()}
+
+    def get(self, key: str) -> str | None:
+        """Return the value for the normalised key."""
+        return self._data.get(normalise(key))
+
+
+class EnvSource:
+    """Configuration source that reads from environment variables."""
+
+    def get(self, key: str) -> str | None:
+        """Return the env var value, trying the original key then uppercase."""
+        value = os.environ.get(key)
+        if value is not None:
+            return value
+        return os.environ.get(key.upper().replace(".", "_"))
+
+
+class DotEnvSource:
+    """Configuration source that parses a ``.env`` file."""
+
+    def __init__(self, path: str = ".env") -> None:
+        self._data: dict[str, str] = {}
+        self._load(path)
+
+    def _load(self, path: str) -> None:
+        """Parse a .env file into the data dict."""
+        try:
+            with open(path) as f:  # noqa: PTH123
+                for line in f:
+                    line = line.strip()  # noqa: PLW2901
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, _, value = line.partition("=")
+                    key = key.strip()
+                    value = value.strip()
+                    if (
+                        len(value) >= 2  # noqa: PLR2004
+                        and value[0] == value[-1]
+                        and value[0] in ('"', "'")
+                    ):
+                        value = value[1:-1]
+                    self._data[normalise(key)] = value
+        except FileNotFoundError:
+            pass
+
+    def get(self, key: str) -> str | None:
+        """Return the value for the normalised key."""
+        return self._data.get(normalise(key))
+
+
+class LayeredSource:
+    """Combine multiple sources with priority (first match wins)."""
+
+    def __init__(self, *sources: ConfigSource) -> None:
+        self._sources = sources
+
+    def get(self, key: str) -> str | None:
+        """Return the first non-None value from the source chain."""
+        for source in self._sources:
+            value = source.get(key)
+            if value is not None:
+                return value
+        return None

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,96 @@
+import os
+import pathlib
+
+from uncoiled import ConfigSource, DictSource, DotEnvSource, EnvSource, LayeredSource
+
+
+class TestDictSource:
+    def test_get_existing_key(self) -> None:
+        source = DictSource({"db.host": "localhost"})
+        assert source.get("db.host") == "localhost"
+
+    def test_get_missing_key(self) -> None:
+        source = DictSource({"db.host": "localhost"})
+        assert source.get("db.port") is None
+
+    def test_normalises_keys(self) -> None:
+        source = DictSource({"DB_HOST": "localhost"})
+        assert source.get("db.host") == "localhost"
+
+    def test_conforms_to_protocol(self) -> None:
+        assert isinstance(DictSource({}), ConfigSource)
+
+
+class TestEnvSource:
+    def test_get_from_env(self) -> None:
+        os.environ["TEST_DB_HOST"] = "localhost"
+        try:
+            source = EnvSource()
+            assert source.get("TEST_DB_HOST") == "localhost"
+        finally:
+            del os.environ["TEST_DB_HOST"]
+
+    def test_get_dotted_key(self) -> None:
+        os.environ["DB_HOST"] = "localhost"
+        try:
+            source = EnvSource()
+            assert source.get("db.host") == "localhost"
+        finally:
+            del os.environ["DB_HOST"]
+
+    def test_get_missing(self) -> None:
+        source = EnvSource()
+        assert source.get("NONEXISTENT_KEY_12345") is None
+
+    def test_conforms_to_protocol(self) -> None:
+        assert isinstance(EnvSource(), ConfigSource)
+
+
+class TestDotEnvSource:
+    def test_parse_simple(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / ".env"
+        p.write_text("DB_HOST=localhost\nDB_PORT=5432\n")
+        source = DotEnvSource(str(p))
+        assert source.get("db.host") == "localhost"
+        assert source.get("db.port") == "5432"
+
+    def test_parse_quoted_values(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / ".env"
+        p.write_text("DB_HOST=\"localhost\"\nDB_NAME='mydb'\n")
+        source = DotEnvSource(str(p))
+        assert source.get("db.host") == "localhost"
+        assert source.get("db.name") == "mydb"
+
+    def test_skip_comments_and_blanks(self, tmp_path: pathlib.Path) -> None:
+        p = tmp_path / ".env"
+        p.write_text("# comment\n\nDB_HOST=localhost\n")
+        source = DotEnvSource(str(p))
+        assert source.get("db.host") == "localhost"
+
+    def test_missing_file(self) -> None:
+        source = DotEnvSource("/nonexistent/.env")
+        assert source.get("anything") is None
+
+    def test_conforms_to_protocol(self) -> None:
+        assert isinstance(DotEnvSource("/nonexistent"), ConfigSource)
+
+
+class TestLayeredSource:
+    def test_first_source_wins(self) -> None:
+        s1 = DictSource({"db.host": "from-s1"})
+        s2 = DictSource({"db.host": "from-s2"})
+        layered = LayeredSource(s1, s2)
+        assert layered.get("db.host") == "from-s1"
+
+    def test_falls_through(self) -> None:
+        s1 = DictSource({})
+        s2 = DictSource({"db.host": "from-s2"})
+        layered = LayeredSource(s1, s2)
+        assert layered.get("db.host") == "from-s2"
+
+    def test_all_miss(self) -> None:
+        layered = LayeredSource(DictSource({}), DictSource({}))
+        assert layered.get("missing") is None
+
+    def test_conforms_to_protocol(self) -> None:
+        assert isinstance(LayeredSource(), ConfigSource)


### PR DESCRIPTION
## Summary

- `ConfigSource` protocol for pluggable config sources
- `DictSource`, `EnvSource`, `DotEnvSource`, `LayeredSource`

Replaces #32

## Test plan

- [x] All source types tested with protocol conformance

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)