### PR TITLE
Add profile resolution from UNCOILED_PROFILES

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -3,6 +3,7 @@
 from importlib import metadata
 
 from ._component import ComponentMetadata, component
+from ._config._profiles import get_active_profiles
 from ._config._relaxed import normalise
 from ._config._sources import (
     ConfigSource,
@@ -48,6 +49,7 @@ __all__ = [
     "call_destroy",
     "call_init",
     "component",
+    "get_active_profiles",
     "inspect_dependencies",
     "normalise",
     "validate_graph",

--- a/src/uncoiled/_config/_profiles.py
+++ b/src/uncoiled/_config/_profiles.py
@@ -1,0 +1,18 @@
+"""Profile resolution via the ``UNCOILED_PROFILES`` environment variable."""
+
+from __future__ import annotations
+
+import os
+
+PROFILES_ENV_VAR = "UNCOILED_PROFILES"
+
+
+def get_active_profiles() -> list[str]:
+    """Return the list of active profiles from the environment.
+
+    Read from ``UNCOILED_PROFILES`` env var (comma-separated).
+    """
+    raw = os.environ.get(PROFILES_ENV_VAR, "")
+    if not raw.strip():
+        return []
+    return [p.strip() for p in raw.split(",") if p.strip()]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,44 @@
+import os
+
+from uncoiled import get_active_profiles
+
+
+class TestGetActiveProfiles:
+    def test_no_env_var(self) -> None:
+        os.environ.pop("UNCOILED_PROFILES", None)
+        assert get_active_profiles() == []
+
+    def test_empty_env_var(self) -> None:
+        os.environ["UNCOILED_PROFILES"] = ""
+        try:
+            assert get_active_profiles() == []
+        finally:
+            del os.environ["UNCOILED_PROFILES"]
+
+    def test_single_profile(self) -> None:
+        os.environ["UNCOILED_PROFILES"] = "prod"
+        try:
+            assert get_active_profiles() == ["prod"]
+        finally:
+            del os.environ["UNCOILED_PROFILES"]
+
+    def test_multiple_profiles(self) -> None:
+        os.environ["UNCOILED_PROFILES"] = "prod,debug"
+        try:
+            assert get_active_profiles() == ["prod", "debug"]
+        finally:
+            del os.environ["UNCOILED_PROFILES"]
+
+    def test_whitespace_handling(self) -> None:
+        os.environ["UNCOILED_PROFILES"] = " prod , debug "
+        try:
+            assert get_active_profiles() == ["prod", "debug"]
+        finally:
+            del os.environ["UNCOILED_PROFILES"]
+
+    def test_trailing_comma(self) -> None:
+        os.environ["UNCOILED_PROFILES"] = "prod,"
+        try:
+            assert get_active_profiles() == ["prod"]
+        finally:
+            del os.environ["UNCOILED_PROFILES"]


### PR DESCRIPTION
## Summary

- `get_active_profiles()` reads comma-separated profiles from `UNCOILED_PROFILES` env var

Replaces #33. Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)