### PR TITLE
Add @config_properties decorator and bind_config

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -3,6 +3,7 @@
 from importlib import metadata
 
 from ._component import ComponentMetadata, component
+from ._config._binding import bind_config, config_properties
 from ._config._profiles import get_active_profiles
 from ._config._relaxed import normalise
 from ._config._sources import (
@@ -45,10 +46,12 @@ __all__ = [
     "TransientScope",
     "async_call_destroy",
     "async_call_init",
+    "bind_config",
     "build_graph",
     "call_destroy",
     "call_init",
     "component",
+    "config_properties",
     "get_active_profiles",
     "inspect_dependencies",
     "normalise",

--- a/src/uncoiled/_config/_binding.py
+++ b/src/uncoiled/_config/_binding.py
@@ -1,0 +1,98 @@
+"""``@config_properties`` decorator for binding config to frozen dataclasses."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import TYPE_CHECKING, get_type_hints
+
+from ._relaxed import normalise
+
+if TYPE_CHECKING:
+    from ._sources import ConfigSource
+
+
+def _parse_bool(value: str) -> bool:
+    """Parse a string to a boolean value."""
+    if value.lower() in ("true", "1", "yes", "on"):
+        return True
+    if value.lower() in ("false", "0", "no", "off"):
+        return False
+    msg = f"Cannot coerce '{value}' to bool"
+    raise ValueError(msg)
+
+
+_COERCIONS: dict[type, object] = {
+    str: str,
+    int: int,
+    float: float,
+    bool: _parse_bool,
+    Path: Path,
+}
+
+
+def _coerce(value: str, target_type: type) -> object:
+    """Coerce a string value to the target type."""
+    if target_type is list or (
+        hasattr(target_type, "__origin__") and target_type.__origin__ is list
+    ):
+        return [item.strip() for item in value.split(",") if item.strip()]
+
+    coercer = _COERCIONS.get(target_type)
+    if coercer is not None:
+        return coercer(value)  # type: ignore[operator]
+
+    return value
+
+
+def config_properties(
+    prefix: str,
+) -> _ConfigPropertiesDecorator:
+    """Decorate a dataclass to bind configuration values by prefix.
+
+    Example::
+
+        @config_properties("db")
+        @dataclass(frozen=True)
+        class DbConfig:
+            host: str = "localhost"
+            port: int = 5432
+
+    """
+    return _ConfigPropertiesDecorator(prefix)
+
+
+class _ConfigPropertiesDecorator:
+    """Return value of ``config_properties(prefix)``."""
+
+    def __init__(self, prefix: str) -> None:
+        self._prefix = prefix
+
+    def __call__(self, cls: type) -> type:
+        """Attach prefix metadata to the class."""
+        cls.__config_prefix__ = self._prefix  # type: ignore[attr-defined]
+        return cls
+
+
+def bind_config[T](cls: type[T], source: ConfigSource) -> T:
+    """Create an instance of a config dataclass by reading values from a source."""
+    prefix = getattr(cls, "__config_prefix__", "")
+    hints = get_type_hints(cls)
+    fields = dataclasses.fields(cls)
+    kwargs: dict[str, object] = {}
+
+    for field in fields:
+        key = f"{prefix}.{field.name}" if prefix else field.name
+        raw = source.get(normalise(key))
+        if raw is not None:
+            kwargs[field.name] = _coerce(raw, hints[field.name])
+        elif (
+            field.default is not dataclasses.MISSING
+            or field.default_factory is not dataclasses.MISSING
+        ):
+            pass  # Let the dataclass use its default
+        else:
+            msg = f"Missing required config value for '{key}'"
+            raise ValueError(msg)
+
+    return cls(**kwargs)

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from uncoiled import DictSource, bind_config, config_properties
+
+MYSQL_PORT = 3306
+POSTGRES_PORT = 5432
+
+
+@config_properties("db")
+@dataclass(frozen=True)
+class DbConfig:
+    host: str = "localhost"
+    port: int = POSTGRES_PORT
+
+
+@config_properties("app")
+@dataclass(frozen=True)
+class AppConfig:
+    name: str = "myapp"
+    debug: bool = False
+    tags: list[str] = ""  # type: ignore[assignment]
+
+
+class TestConfigProperties:
+    def test_binds_from_source(self) -> None:
+        source = DictSource({"db.host": "remotehost", "db.port": "3306"})
+        config = bind_config(DbConfig, source)
+        assert config.host == "remotehost"
+        assert config.port == MYSQL_PORT
+
+    def test_uses_defaults(self) -> None:
+        source = DictSource({})
+        config = bind_config(DbConfig, source)
+        assert config.host == "localhost"
+        assert config.port == POSTGRES_PORT
+
+    def test_partial_override(self) -> None:
+        source = DictSource({"db.host": "custom"})
+        config = bind_config(DbConfig, source)
+        assert config.host == "custom"
+        assert config.port == POSTGRES_PORT
+
+    def test_bool_coercion(self) -> None:
+        source = DictSource({"app.name": "test", "app.debug": "true"})
+        config = bind_config(AppConfig, source)
+        assert config.debug is True
+
+    def test_list_coercion(self) -> None:
+        source = DictSource({"app.name": "test", "app.tags": "a, b, c"})
+        config = bind_config(AppConfig, source)
+        assert config.tags == ["a", "b", "c"]
+
+    def test_path_coercion(self) -> None:
+        @config_properties("fs")
+        @dataclass(frozen=True)
+        class FsConfig:
+            root: Path = Path()
+
+        source = DictSource({"fs.root": "/opt/data"})
+        config = bind_config(FsConfig, source)
+        assert config.root == Path("/opt/data")
+
+    def test_missing_required_raises(self) -> None:
+        @config_properties("svc")
+        @dataclass(frozen=True)
+        class SvcConfig:
+            url: str
+
+        source = DictSource({})
+        with pytest.raises(ValueError, match="Missing required"):
+            bind_config(SvcConfig, source)


### PR DESCRIPTION
## Summary

- `@config_properties(prefix)` marks dataclass for config binding
- `bind_config(cls, source)` creates instances with type coercion (str, int, float, bool, Path, list[str])

Replaces #37. Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)