### PR TITLE
Fix review issues: qualifier cache, close errors, transient leak, scan walk

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -77,7 +77,7 @@ class Container:
             provides=type_,
             qualifier=qualifier,
         )
-        self._scopes[Scope.SINGLETON].put(type_, instance)
+        self._scopes[Scope.SINGLETON].put(type_, instance, qualifier)
 
     def register_factory(
         self,
@@ -106,10 +106,7 @@ class Container:
 
     def _scan_module(self, mod: ModuleType) -> None:
         """Scan a single module and its submodules for components."""
-        for _name, obj in inspect.getmembers(mod, inspect.isclass):
-            meta: ComponentMetadata | None = getattr(obj, "__uncoiled__", None)
-            if meta is not None:
-                self.register(obj, scope=meta.scope, qualifier=meta.qualifier)
+        self._register_from_module(mod)
 
         if hasattr(mod, "__path__"):
             for _importer, modname, _ispkg in pkgutil.walk_packages(
@@ -117,7 +114,14 @@ class Container:
                 prefix=mod.__name__ + ".",
             ):
                 submod = importlib.import_module(modname)
-                self._scan_module(submod)
+                self._register_from_module(submod)
+
+    def _register_from_module(self, mod: ModuleType) -> None:
+        """Register all ``@component``-decorated classes found in a module."""
+        for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            meta: ComponentMetadata | None = getattr(obj, "__uncoiled__", None)
+            if meta is not None:
+                self.register(obj, scope=meta.scope, qualifier=meta.qualifier)
 
     def validate(self) -> None:
         """Validate the dependency graph eagerly."""
@@ -128,19 +132,29 @@ class Container:
         self.validate()
         singleton = self._scopes[Scope.SINGLETON]
         for key, node in self._registrations.items():
-            if node.scope is Scope.SINGLETON and singleton.get(node.provides) is None:
+            if (
+                node.scope is Scope.SINGLETON
+                and singleton.get(node.provides, key[1]) is None
+            ):
                 self._resolve(node.provides, key[1])
         self._started = True
 
     def close(self) -> None:
         """Destroy instances in reverse creation order."""
+        errors: list[Exception] = []
         for instance in reversed(self._instances):
-            destroy_method = self._destroy_hooks.get(type(instance))
-            call_destroy(instance, destroy_method)
+            try:
+                destroy_method = self._destroy_hooks.get(type(instance))
+                call_destroy(instance, destroy_method)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
         self._instances.clear()
         for scope_manager in self._scopes.values():
             scope_manager.clear()
         self._started = False
+        if errors:
+            msg = "errors during container close"
+            raise ExceptionGroup(msg, errors)
 
     def get[T](self, type_: type[T], qualifier: str | None = None) -> T:
         """Resolve a single instance of the given type."""
@@ -168,16 +182,17 @@ class Container:
 
         scope_manager = self._scopes.get(node.scope)
         if scope_manager:
-            cached = scope_manager.get(type_)
+            cached = scope_manager.get(type_, qualifier)
             if cached is not None:
                 return cached
 
         instance = self._create_instance(node)
 
         if scope_manager:
-            scope_manager.put(type_, instance)
+            scope_manager.put(type_, instance, qualifier)
 
-        self._instances.append(instance)
+        if node.scope is not Scope.TRANSIENT or node.impl in self._destroy_hooks:
+            self._instances.append(instance)
         call_init(instance, self._init_hooks.get(node.impl))
 
         return instance  # type: ignore[return-value]

--- a/src/uncoiled/_scope.py
+++ b/src/uncoiled/_scope.py
@@ -16,11 +16,11 @@ class ScopeManager(Protocol):
         """Return the scope this manager handles."""
         ...
 
-    def get[T](self, key: type[T]) -> T | None:
+    def get[T](self, key: type[T], qualifier: str | None = None) -> T | None:
         """Return a cached instance or None."""
         ...
 
-    def put[T](self, key: type[T], instance: T) -> None:
+    def put[T](self, key: type[T], instance: T, qualifier: str | None = None) -> None:
         """Store an instance in this scope."""
         ...
 
@@ -33,20 +33,20 @@ class SingletonScope:
     """Scope that caches a single instance per type for the container's lifetime."""
 
     def __init__(self) -> None:
-        self._instances: dict[type, object] = {}
+        self._instances: dict[tuple[type, str | None], object] = {}
 
     @property
     def scope(self) -> Scope:
         """Return the scope type."""
         return Scope.SINGLETON
 
-    def get[T](self, key: type[T]) -> T | None:
+    def get[T](self, key: type[T], qualifier: str | None = None) -> T | None:
         """Return the cached instance or None."""
-        return self._instances.get(key)  # type: ignore[return-value]
+        return self._instances.get((key, qualifier))  # type: ignore[return-value]
 
-    def put[T](self, key: type[T], instance: T) -> None:
+    def put[T](self, key: type[T], instance: T, qualifier: str | None = None) -> None:
         """Cache the instance."""
-        self._instances[key] = instance
+        self._instances[(key, qualifier)] = instance
 
     def clear(self) -> None:
         """Remove all cached instances."""
@@ -61,11 +61,20 @@ class TransientScope:
         """Return the scope type."""
         return Scope.TRANSIENT
 
-    def get[T](self, key: type[T]) -> T | None:  # noqa: ARG002
+    def get[T](
+        self,
+        key: type[T],  # noqa: ARG002
+        qualifier: str | None = None,  # noqa: ARG002
+    ) -> T | None:
         """Return None; transient instances are never cached."""
         return None
 
-    def put[T](self, key: type[T], instance: T) -> None:
+    def put[T](
+        self,
+        key: type[T],
+        instance: T,
+        qualifier: str | None = None,
+    ) -> None:
         """Do nothing; transient instances are not cached."""
 
     def clear(self) -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -172,6 +172,98 @@ class TestContainerLifecycle:
             assert isinstance(repo, Repository)
 
 
+class TestSingletonQualifierIsolation:
+    def test_different_qualifiers_return_different_instances(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        class RepoB(Repository):
+            pass
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="a")
+        c.register(RepoB, provides=Repository, qualifier="b")
+
+        a = c.get(Repository, qualifier="a")
+        b = c.get(Repository, qualifier="b")
+        assert isinstance(a, RepoA)
+        assert isinstance(b, RepoB)
+
+    def test_register_instance_with_qualifier(self) -> None:
+        repo_a = Repository()
+        repo_b = Repository()
+        c = Container()
+        c.register_instance(repo_a, qualifier="a")
+        c.register_instance(repo_b, qualifier="b")
+        assert c.get(Repository, qualifier="a") is repo_a
+        assert c.get(Repository, qualifier="b") is repo_b
+
+
+class TestCloseErrorHandling:
+    def test_close_continues_on_destroy_error(self) -> None:
+        class FailResource:
+            def close(self) -> None:
+                msg = "fail"
+                raise RuntimeError(msg)
+
+        class GoodResource:
+            closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        c = Container()
+        c.register(GoodResource, destroy_method="close")
+        c.register(FailResource, destroy_method="close")
+        c.start()
+        good = c.get(GoodResource)
+        with pytest.raises(ExceptionGroup):
+            c.close()
+        assert good.closed
+
+    def test_close_aggregates_multiple_errors(self) -> None:
+        class FailA:
+            def close(self) -> None:
+                msg = "a"
+                raise RuntimeError(msg)
+
+        class FailB:
+            def close(self) -> None:
+                msg = "b"
+                raise RuntimeError(msg)
+
+        c = Container()
+        c.register(FailA, destroy_method="close")
+        c.register(FailB, destroy_method="close")
+        c.start()
+        expected_count = 2
+        with pytest.raises(ExceptionGroup) as exc_info:
+            c.close()
+        assert len(exc_info.value.exceptions) == expected_count
+
+
+class TestTransientMemoryLeak:
+    def test_transient_without_destroy_not_tracked(self) -> None:
+        c = Container()
+        c.register(Repository, scope=Scope.TRANSIENT)
+        resolve_count = 10
+        for _ in range(resolve_count):
+            c.get(Repository)
+        assert len(c._instances) == 0  # noqa: SLF001
+
+    def test_transient_with_destroy_hook_tracked(self) -> None:
+        class Resource:
+            def close(self) -> None:
+                pass
+
+        c = Container()
+        c.register(Resource, scope=Scope.TRANSIENT, destroy_method="close")
+        resolve_count = 3
+        for _ in range(resolve_count):
+            c.get(Resource)
+        assert len(c._instances) == resolve_count  # noqa: SLF001
+
+
 class TestContainerScan:
     def test_scan_finds_decorated_classes(self) -> None:
         @component

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -29,6 +29,13 @@ class TestSingletonScope:
     def test_conforms_to_protocol(self) -> None:
         assert isinstance(SingletonScope(), ScopeManager)
 
+    def test_qualifier_isolation(self) -> None:
+        scope = SingletonScope()
+        scope.put(str, "default")
+        scope.put(str, "primary", qualifier="primary")
+        assert scope.get(str) == "default"
+        assert scope.get(str, qualifier="primary") == "primary"
+
 
 class TestTransientScope:
     def test_scope_type(self) -> None:


### PR DESCRIPTION
## Summary
- **#39**: Singleton scope cache now keys on `(type, qualifier)` instead of just `type`, fixing shared cache slots across qualifiers
- **#40**: `Container.close()` collects destroy errors and raises them as an `ExceptionGroup` after all components are cleaned up
- **#41**: Transient instances without destroy hooks are no longer tracked in `_instances`, preventing unbounded memory growth
- **#42**: `_scan_module` no longer recursively calls itself — `walk_packages` already handles recursion, so a separate `_register_from_module` helper avoids exponential re-walks

## Test plan
- [x] New test: singleton scope correctly isolates instances by qualifier
- [x] New test: `register_instance` with qualifiers returns correct instances
- [x] New test: `close()` continues destroying remaining components after an error
- [x] New test: `close()` aggregates multiple errors into `ExceptionGroup`
- [x] New test: transient instances without destroy hooks don't accumulate in `_instances`
- [x] New test: transient instances with destroy hooks are still tracked
- [x] All 127 tests pass, linting and formatting clean

Closes #39, closes #40, closes #41, closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)