### PR TITLE
Fix optional dependency default value override

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -223,7 +223,7 @@ class Container:
                     dep.required_type,
                     dep.qualifier,
                 )
-            elif dep.optional:
+            elif dep.optional and not dep.has_default:
                 kwargs[dep.name] = None
         else:
             kwargs[dep.name] = self._resolve(dep.required_type, dep.qualifier)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -78,6 +78,28 @@ class TestContainerResolution:
         c.register(OptService)
         assert isinstance(c.get(OptService).repo, Repository)
 
+    def test_optional_with_default_preserves_default(self) -> None:
+        sentinel = object()
+
+        class OptService:
+            def __init__(self, repo: Repository | None = sentinel) -> None:  # type: ignore[assignment]
+                self.repo = repo
+
+        c = Container()
+        c.register(OptService)
+        assert c.get(OptService).repo is sentinel
+
+    def test_non_optional_with_default_preserves_default(self) -> None:
+        default_repo = Repository()
+
+        class OptService:
+            def __init__(self, repo: Repository = default_repo) -> None:
+                self.repo = repo
+
+        c = Container()
+        c.register(OptService)
+        assert c.get(OptService).repo is default_repo
+
     def test_list_dependency(self) -> None:
         class RepoA(Repository):
             pass


### PR DESCRIPTION
## Summary
- When a dependency is both optional (`X | None`) and has a default value, and is not registered, the container was explicitly setting it to `None` instead of letting the class default apply
- One-line fix: only set `None` when `optional=True` and `has_default=False`

## Test plan
- [x] New test: optional param with non-None default preserves default when unregistered
- [x] New test: non-optional param with default preserves default when unregistered
- [x] Existing optional tests still pass
- [x] All 129 tests pass, linting and formatting clean

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)