### PR TITLE
Reject unsupported scopes at registration time

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -48,6 +48,7 @@ class Container:
         destroy_method: str | None = None,
     ) -> None:
         """Register a class as a component."""
+        self._check_scope(scope)
         provides = provides or cls
         key = (provides, qualifier)
         self._registrations[key] = ComponentNode(
@@ -88,6 +89,7 @@ class Container:
         qualifier: str | None = None,
     ) -> None:
         """Register a factory callable for a type."""
+        self._check_scope(scope)
         key = (return_type, qualifier)
         self._registrations[key] = ComponentNode(
             impl=return_type,
@@ -227,6 +229,12 @@ class Container:
                 kwargs[dep.name] = None
         else:
             kwargs[dep.name] = self._resolve(dep.required_type, dep.qualifier)
+
+    def _check_scope(self, scope: Scope) -> None:
+        """Raise if the scope has no registered manager."""
+        if scope not in self._scopes:
+            msg = f"No scope manager registered for {scope.value!r}"
+            raise ValueError(msg)
 
     def __enter__(self) -> Self:
         """Start the container as a context manager."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -36,6 +36,16 @@ class TestContainerRegistration:
         c.register_factory(Repository, return_type=Repository)
         assert isinstance(c.get(Repository), Repository)
 
+    def test_register_rejects_unsupported_scope(self) -> None:
+        c = Container()
+        with pytest.raises(ValueError, match="request"):
+            c.register(Repository, scope=Scope.REQUEST)
+
+    def test_register_factory_rejects_unsupported_scope(self) -> None:
+        c = Container()
+        with pytest.raises(ValueError, match="request"):
+            c.register_factory(Repository, return_type=Repository, scope=Scope.REQUEST)
+
 
 class TestContainerResolution:
     def test_singleton_scope(self) -> None:


### PR DESCRIPTION
## Summary
- `register()` and `register_factory()` now raise `ValueError` if the requested scope has no registered manager
- Catches the problem early instead of silently producing broken behavior (no caching + unbounded memory growth)
- Adds `_check_scope` helper used by both registration methods

## Test plan
- [x] New test: `register` with `Scope.REQUEST` raises `ValueError`
- [x] New test: `register_factory` with `Scope.REQUEST` raises `ValueError`
- [x] All 129 tests pass, linting and formatting clean

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)