### PR TITLE
Add Container.override() and Container.fork()

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import inspect
 import pkgutil
@@ -14,6 +15,7 @@ from ._scope import SingletonScope, TransientScope
 from ._types import Scope
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from types import ModuleType
 
     from ._component import ComponentMetadata
@@ -229,6 +231,56 @@ class Container:
                 kwargs[dep.name] = None
         else:
             kwargs[dep.name] = self._resolve(dep.required_type, dep.qualifier)
+
+    @contextlib.contextmanager
+    def override(
+        self,
+        type_: type,
+        replacement: object,
+        *,
+        qualifier: str | None = None,
+    ) -> Iterator[None]:
+        """Temporarily replace a registration.
+
+        *replacement* may be a class (re-registered) or an instance.
+        """
+        key = (type_, qualifier)
+        old_node = self._registrations.get(key)
+        singleton = self._scopes[Scope.SINGLETON]
+        old_cached = singleton.get(type_, qualifier)
+
+        # Remove existing cache entry so the override takes effect
+        singleton.remove(type_, qualifier)
+
+        # Install the replacement
+        if isinstance(replacement, type):
+            self.register(replacement, provides=type_, qualifier=qualifier)
+        else:
+            self.register_instance(replacement, type_=type_, qualifier=qualifier)
+
+        try:
+            yield
+        finally:
+            # Remove the override's cache entry
+            singleton.remove(type_, qualifier)
+
+            # Restore original registration (or remove if there was none)
+            if old_node is None:
+                self._registrations.pop(key, None)
+            else:
+                self._registrations[key] = old_node
+
+            # Restore original cached instance
+            if old_cached is not None:
+                singleton.put(type_, old_cached, qualifier)
+
+    def fork(self) -> Container:
+        """Create a child container with shared registrations."""
+        child = Container()
+        child._registrations = dict(self._registrations)
+        child._init_hooks = dict(self._init_hooks)
+        child._destroy_hooks = dict(self._destroy_hooks)
+        return child
 
     def _check_scope(self, scope: Scope) -> None:
         """Raise if the scope has no registered manager."""

--- a/src/uncoiled/_scope.py
+++ b/src/uncoiled/_scope.py
@@ -24,6 +24,10 @@ class ScopeManager(Protocol):
         """Store an instance in this scope."""
         ...
 
+    def remove(self, key: type, qualifier: str | None = None) -> None:
+        """Remove a single cached instance."""
+        ...
+
     def clear(self) -> None:
         """Remove all instances from this scope."""
         ...
@@ -47,6 +51,10 @@ class SingletonScope:
     def put[T](self, key: type[T], instance: T, qualifier: str | None = None) -> None:
         """Cache the instance."""
         self._instances[(key, qualifier)] = instance
+
+    def remove(self, key: type, qualifier: str | None = None) -> None:
+        """Remove a cached instance."""
+        self._instances.pop((key, qualifier), None)
 
     def clear(self) -> None:
         """Remove all cached instances."""
@@ -76,6 +84,13 @@ class TransientScope:
         qualifier: str | None = None,
     ) -> None:
         """Do nothing; transient instances are not cached."""
+
+    def remove(
+        self,
+        key: type,
+        qualifier: str | None = None,
+    ) -> None:
+        """No-op (nothing to remove)."""
 
     def clear(self) -> None:
         """No-op (nothing to clear)."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -296,6 +296,131 @@ class TestTransientMemoryLeak:
         assert len(c._instances) == resolve_count  # noqa: SLF001
 
 
+class TestContainerOverride:
+    def test_override_replaces_with_class(self) -> None:
+        class MockRepo(Repository):
+            pass
+
+        c = Container()
+        c.register(Repository)
+        c.start()
+        original = c.get(Repository)
+        with c.override(Repository, MockRepo):
+            assert isinstance(c.get(Repository), MockRepo)
+        assert c.get(Repository) is original
+
+    def test_override_replaces_with_instance(self) -> None:
+        mock = Repository()
+        c = Container()
+        c.register(Repository)
+        c.start()
+        with c.override(Repository, mock):
+            assert c.get(Repository) is mock
+
+    def test_override_restores_cached_singleton(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.start()
+        original = c.get(Repository)
+        with c.override(Repository, Repository):
+            pass
+        assert c.get(Repository) is original
+
+    def test_override_nonexistent_key(self) -> None:
+        c = Container()
+        with c.override(Repository, Repository):
+            assert isinstance(c.get(Repository), Repository)
+        with pytest.raises(LookupError):
+            c.get(Repository)
+
+    def test_override_with_qualifier(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        class RepoB(Repository):
+            pass
+
+        class MockRepo(Repository):
+            pass
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="a")
+        c.register(RepoB, provides=Repository, qualifier="b")
+        c.start()
+        with c.override(Repository, MockRepo, qualifier="a"):
+            assert isinstance(c.get(Repository, qualifier="a"), MockRepo)
+            assert isinstance(c.get(Repository, qualifier="b"), RepoB)
+
+    def test_nested_overrides(self) -> None:
+        class MockA(Repository):
+            pass
+
+        class MockB(Repository):
+            pass
+
+        c = Container()
+        c.register(Repository)
+        c.start()
+        original = c.get(Repository)
+        with c.override(Repository, MockA):
+            assert isinstance(c.get(Repository), MockA)
+            with c.override(Repository, MockB):
+                assert isinstance(c.get(Repository), MockB)
+            assert isinstance(c.get(Repository), MockA)
+        assert c.get(Repository) is original
+
+
+class TestContainerFork:
+    def test_fork_shares_registrations(self) -> None:
+        c = Container()
+        c.register(Repository)
+        child = c.fork()
+        assert isinstance(child.get(Repository), Repository)
+
+    def test_fork_independent_singleton_cache(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.start()
+        child = c.fork()
+        assert c.get(Repository) is not child.get(Repository)
+
+    def test_fork_does_not_affect_parent(self) -> None:
+        class Extra:
+            pass
+
+        c = Container()
+        c.register(Repository)
+        child = c.fork()
+        child.register(Extra)
+        assert isinstance(child.get(Extra), Extra)
+        with pytest.raises(LookupError):
+            c.get(Extra)
+
+    def test_fork_inherits_lifecycle_hooks(self) -> None:
+        class Service:
+            started = False
+
+            def start(self) -> None:
+                self.started = True
+
+        c = Container()
+        c.register(Service, init_method="start")
+        child = c.fork()
+        svc = child.get(Service)
+        assert svc.started
+
+    def test_fork_child_can_override_registration(self) -> None:
+        class MockRepo(Repository):
+            pass
+
+        c = Container()
+        c.register(Repository)
+        child = c.fork()
+        child.register(MockRepo, provides=Repository)
+        assert isinstance(child.get(Repository), MockRepo)
+        assert not isinstance(c.get(Repository), MockRepo)
+
+
 class TestContainerScan:
     def test_scan_finds_decorated_classes(self) -> None:
         @component


### PR DESCRIPTION
## Summary
- `override(type_, replacement, *, qualifier)` — context manager that temporarily swaps a registration (class or instance), restoring the original + cached singleton on exit
- `fork()` — creates a child container sharing registrations and hooks but with an independent singleton cache
- Adds `remove()` to `ScopeManager` protocol for clean cache entry removal

## Test plan
- [x] Override replaces with class, restores original on exit
- [x] Override replaces with instance
- [x] Override restores cached singleton identity
- [x] Override on nonexistent key cleans up on exit
- [x] Override with qualifier leaves other qualifiers unaffected
- [x] Nested overrides restore correctly at each level
- [x] Fork shares registrations
- [x] Fork has independent singleton cache
- [x] Fork mutations don't affect parent
- [x] Fork inherits lifecycle hooks
- [x] Fork child can override registrations independently
- [x] All 142 tests pass

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)