### PR TITLE
Add pytest plugin with fixtures and override marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ test = [
     "pytest>=9.0.2",
 ]
 
+[project.entry-points.pytest11]
+uncoiled = "uncoiled._pytest"
+
+[tool.pytest.ini_options]
+addopts = ["-p", "pytester"]
+
 [tool.coverage.run]
 omit = ["tests/**"]
 
@@ -53,4 +59,8 @@ ignore = [
 "tests/**" = [
     "D",
     "S101",
+]
+"src/uncoiled/_pytest.py" = [
+    "PT004",
+    "PT005",
 ]

--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -18,6 +18,7 @@ from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
 from ._lifecycle import async_call_destroy, async_call_init, call_destroy, call_init
+from ._pytest import Inject
 from ._qualifiers import Qualifier
 from ._scope import ScopeManager, SingletonScope, TransientScope
 from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
@@ -37,6 +38,7 @@ __all__ = [
     "EnvSource",
     "Factory",
     "FailureKind",
+    "Inject",
     "LayeredSource",
     "Qualifier",
     "ResolutionFailure",

--- a/src/uncoiled/_pytest.py
+++ b/src/uncoiled/_pytest.py
@@ -1,0 +1,70 @@
+"""Pytest plugin for uncoiled — auto-discovered via entry point."""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ._container import Container
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class Inject:
+    """Function-scoped helper to resolve types from the container."""
+
+    def __init__(self, container: Container) -> None:
+        self._container = container
+
+    def __getitem__[T](self, key: type[T]) -> T:
+        """Resolve a type from the container."""
+        return self._container.get(key)
+
+
+@pytest.fixture(scope="session")
+def uncoiled_container() -> Iterator[Container]:
+    """Session-scoped fixture providing a started container."""
+    container = Container()
+    container.start()
+    yield container
+    container.close()
+
+
+@pytest.fixture
+def inject(uncoiled_container: Container) -> Inject:
+    """Function-scoped fixture to resolve types from the container."""
+    return Inject(uncoiled_container)
+
+
+@pytest.fixture(autouse=True)
+def _uncoiled_overrides(
+    request: pytest.FixtureRequest,
+    uncoiled_container: Container,
+) -> Iterator[None]:
+    """Apply ``uncoiled_override`` markers as overrides for each test."""
+    markers = list(request.node.iter_markers("uncoiled_override"))
+    if not markers:
+        yield
+        return
+
+    with contextlib.ExitStack() as stack:
+        for marker in markers:
+            type_ = marker.args[0]
+            replacement = marker.args[1]
+            qualifier = marker.kwargs.get("qualifier")
+            stack.enter_context(
+                uncoiled_container.override(type_, replacement, qualifier=qualifier),
+            )
+        yield
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the ``uncoiled_override`` marker."""
+    config.addinivalue_line(
+        "markers",
+        "uncoiled_override(type_, replacement, *, qualifier=None): "
+        "override a container registration for the duration of the test",
+    )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,113 @@
+import pytest
+
+from uncoiled import Container, Inject
+
+
+class Repository:
+    pass
+
+
+class MockRepo(Repository):
+    pass
+
+
+class TestInject:
+    def test_getitem_resolves_type(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.start()
+        inject = Inject(c)
+        assert isinstance(inject[Repository], Repository)
+
+    def test_getitem_raises_for_missing(self) -> None:
+        c = Container()
+        c.start()
+        inject = Inject(c)
+        with pytest.raises(LookupError):
+            inject[Repository]
+
+
+class TestPluginFixtures:
+    """Test plugin fixtures using pytester."""
+
+    @pytest.fixture
+    def configured_pytester(self, pytester: pytest.Pytester) -> pytest.Pytester:
+        pytester.makeconftest(
+            """\
+import pytest
+from uncoiled import Container
+
+class Repo:
+    pass
+
+class MockRepo(Repo):
+    pass
+
+@pytest.fixture(scope="session")
+def uncoiled_container():
+    c = Container()
+    c.register(Repo)
+    c.start()
+    yield c
+    c.close()
+"""
+        )
+        return pytester
+
+    def test_inject_fixture(self, configured_pytester: pytest.Pytester) -> None:
+        configured_pytester.makepyfile(
+            """\
+def test_inject(inject):
+    from uncoiled import Inject
+    assert isinstance(inject, Inject)
+"""
+        )
+        result = configured_pytester.runpytest()
+        result.assert_outcomes(passed=1)
+
+    def test_inject_getitem(self, configured_pytester: pytest.Pytester) -> None:
+        configured_pytester.makepyfile(
+            """\
+def test_resolve(inject):
+    from conftest import Repo
+    assert isinstance(inject[Repo], Repo)
+"""
+        )
+        result = configured_pytester.runpytest()
+        result.assert_outcomes(passed=1)
+
+    def test_override_marker(self, configured_pytester: pytest.Pytester) -> None:
+        configured_pytester.makepyfile(
+            """\
+import pytest
+from conftest import Repo, MockRepo
+
+@pytest.mark.uncoiled_override(Repo, MockRepo)
+def test_overridden(inject):
+    assert isinstance(inject[Repo], MockRepo)
+
+def test_not_overridden(inject):
+    result = inject[Repo]
+    assert type(result) is Repo
+"""
+        )
+        result = configured_pytester.runpytest()
+        result.assert_outcomes(passed=2)
+
+    def test_override_marker_with_instance(
+        self, configured_pytester: pytest.Pytester
+    ) -> None:
+        configured_pytester.makepyfile(
+            """\
+import pytest
+from conftest import Repo
+
+sentinel = Repo()
+
+@pytest.mark.uncoiled_override(Repo, sentinel)
+def test_overridden_instance(inject):
+    assert inject[Repo] is sentinel
+"""
+        )
+        result = configured_pytester.runpytest()
+        result.assert_outcomes(passed=1)


### PR DESCRIPTION
## Summary
- New `uncoiled._pytest` module, auto-discovered via `pytest11` entry point
- `uncoiled_container` session-scoped fixture (users override in conftest to register their components)
- `inject` function-scoped fixture with `__getitem__` for resolving types
- `@pytest.mark.uncoiled_override(Type, Replacement)` marker for per-test overrides
- `Inject` class exported from `uncoiled` package

## Test plan
- [x] `Inject.__getitem__` resolves registered types
- [x] `Inject.__getitem__` raises `LookupError` for missing types
- [x] `inject` fixture provides an `Inject` instance (pytester)
- [x] `inject[Type]` resolves from the container (pytester)
- [x] `uncoiled_override` marker swaps registration for one test, restores for next (pytester)
- [x] `uncoiled_override` with instance works (pytester)
- [x] All 148 tests pass

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)