### PR TITLE
Resolve and validate factory function dependencies

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -93,13 +93,15 @@ class Container:
         """Register a factory callable for a type."""
         self._check_scope(scope)
         key = (return_type, qualifier)
-        self._registrations[key] = ComponentNode(
+        node = ComponentNode(
             impl=return_type,
             provides=return_type,
             qualifier=qualifier,
             scope=scope,
             factory=factory,
         )
+        node.dependencies = inspect_dependencies(factory)
+        self._registrations[key] = node
 
     def scan(self, *modules: str | ModuleType) -> None:
         """Scan modules for ``@component``-decorated classes and register them."""
@@ -203,13 +205,13 @@ class Container:
 
     def _create_instance(self, node: ComponentNode) -> object:
         """Create an instance from a ComponentNode."""
-        if node.factory is not None:
-            return node.factory()  # type: ignore[operator]
-
-        deps = inspect_dependencies(node.impl)
         kwargs: dict[str, object] = {}
-        for dep in deps:
+        for dep in node.dependencies:
             self._resolve_dependency(dep, kwargs)
+
+        if node.factory is not None:
+            return node.factory(**kwargs)  # type: ignore[operator]
+
         return node.impl(**kwargs)
 
     def _resolve_dependency(

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -47,7 +47,8 @@ def build_graph(
         in_degree.setdefault(key, 0)
 
     for key, node in registrations.items():
-        node.dependencies = inspect_dependencies(node.impl)
+        target = node.factory if node.factory is not None else node.impl
+        node.dependencies = inspect_dependencies(target)
         for dep in node.dependencies:
             dep_key = _type_key(dep.required_type, dep.qualifier)
 

--- a/src/uncoiled/_inspection.py
+++ b/src/uncoiled/_inspection.py
@@ -33,18 +33,25 @@ def _is_optional_union(annotation: object) -> type | None:
     return None
 
 
-def inspect_dependencies(cls: type) -> list[DependencySpec]:
-    """Extract dependency specifications from a class's ``__init__`` parameters.
+def inspect_dependencies(target: object) -> list[DependencySpec]:
+    """Extract dependency specifications from a callable's parameters.
 
-    Inspects the ``__init__`` signature and type annotations to determine
-    what dependencies a class requires for construction.
+    For classes, inspects ``__init__``. For functions, inspects the
+    function signature directly.
     """
+    if isinstance(target, type):
+        func = target.__init__
+    elif callable(target):
+        func = target
+    else:
+        return []
+
     try:
-        hints = inspect.get_annotations(cls.__init__, eval_str=True)
+        hints = inspect.get_annotations(func, eval_str=True)
     except Exception:  # noqa: BLE001
         return []
 
-    sig = inspect.signature(cls.__init__)
+    sig = inspect.signature(func)
     specs: list[DependencySpec] = []
 
     for name, param in sig.parameters.items():

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -36,6 +36,26 @@ class TestContainerRegistration:
         c.register_factory(Repository, return_type=Repository)
         assert isinstance(c.get(Repository), Repository)
 
+    def test_register_factory_resolves_dependencies(self) -> None:
+        def make_service(repo: Repository) -> UserService:
+            return UserService(repo)
+
+        c = Container()
+        c.register(Repository)
+        c.register_factory(make_service, return_type=UserService)
+        svc = c.get(UserService)
+        assert isinstance(svc, UserService)
+        assert isinstance(svc.repo, Repository)
+
+    def test_register_factory_validates_dependencies(self) -> None:
+        def make_service(repo: Repository) -> UserService:
+            return UserService(repo)
+
+        c = Container()
+        c.register_factory(make_service, return_type=UserService)
+        with pytest.raises(DependencyResolutionError):
+            c.validate()
+
     def test_register_rejects_unsupported_scope(self) -> None:
         c = Container()
         with pytest.raises(ValueError, match="request"):


### PR DESCRIPTION
## Summary
- `inspect_dependencies` now accepts any callable (class or function), not just classes
- `register_factory()` inspects factory params and stores them as node dependencies
- `_create_instance` resolves factory deps into kwargs before calling the factory
- `build_graph` validates factory deps (inspects the factory, not the return type)

## Test plan
- [x] Factory with dependencies resolves them from the container
- [x] Factory with missing dependencies fails at `validate()` time
- [x] Existing zero-arg factory test still passes
- [x] All 150 tests pass

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)