### PR TITLE
Add lifecycle hooks to register_instance and register_factory

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -71,6 +71,7 @@ class Container:
         *,
         type_: type | None = None,
         qualifier: str | None = None,
+        destroy_method: str | None = None,
     ) -> None:
         """Register a pre-constructed instance."""
         type_ = type_ or type(instance)
@@ -81,14 +82,19 @@ class Container:
             qualifier=qualifier,
         )
         self._scopes[Scope.SINGLETON].put(type_, instance, qualifier)
+        self._instances.append(instance)
+        if destroy_method:
+            self._destroy_hooks[type_] = destroy_method
 
-    def register_factory(
+    def register_factory(  # noqa: PLR0913
         self,
         factory: object,
         *,
         return_type: type,
         scope: Scope = Scope.SINGLETON,
         qualifier: str | None = None,
+        init_method: str | None = None,
+        destroy_method: str | None = None,
     ) -> None:
         """Register a factory callable for a type."""
         self._check_scope(scope)
@@ -102,6 +108,10 @@ class Container:
         )
         node.dependencies = inspect_dependencies(factory)
         self._registrations[key] = node
+        if init_method:
+            self._init_hooks[return_type] = init_method
+        if destroy_method:
+            self._destroy_hooks[return_type] = destroy_method
 
     def scan(self, *modules: str | ModuleType) -> None:
         """Scan modules for ``@component``-decorated classes and register them."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -223,6 +223,45 @@ class TestContainerLifecycle:
             repo = c.get(Repository)
             assert isinstance(repo, Repository)
 
+    def test_register_instance_destroy_method(self) -> None:
+        class Resource:
+            closed = False
+
+            def shutdown(self) -> None:
+                self.closed = True
+
+        res = Resource()
+        c = Container()
+        c.register_instance(res, destroy_method="shutdown")
+        c.close()
+        assert res.closed
+
+    def test_register_factory_init_method(self) -> None:
+        class Service:
+            started = False
+
+            def start(self) -> None:
+                self.started = True
+
+        c = Container()
+        c.register_factory(Service, return_type=Service, init_method="start")
+        svc = c.get(Service)
+        assert svc.started
+
+    def test_register_factory_destroy_method(self) -> None:
+        class Resource:
+            closed = False
+
+            def shutdown(self) -> None:
+                self.closed = True
+
+        c = Container()
+        c.register_factory(Resource, return_type=Resource, destroy_method="shutdown")
+        c.start()
+        res = c.get(Resource)
+        c.close()
+        assert res.closed
+
 
 class TestSingletonQualifierIsolation:
     def test_different_qualifiers_return_different_instances(self) -> None:


### PR DESCRIPTION
## Summary
- `register_instance()` now accepts `destroy_method` and tracks the instance in `_instances` for cleanup during `close()`
- `register_factory()` now accepts `init_method` and `destroy_method`, consistent with `register()`

## Test plan
- [x] `register_instance` with `destroy_method` calls it on `close()`
- [x] `register_factory` with `init_method` calls it after creation
- [x] `register_factory` with `destroy_method` calls it on `close()`
- [x] All 151 tests pass

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)