### PR TITLE
Validate lifecycle method names at registration time

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -61,8 +61,10 @@ class Container:
         )
         self._registrations[key].dependencies = inspect_dependencies(cls)
         if init_method:
+            self._check_lifecycle_method(cls, init_method, "init_method")
             self._init_hooks[cls] = init_method
         if destroy_method:
+            self._check_lifecycle_method(cls, destroy_method, "destroy_method")
             self._destroy_hooks[cls] = destroy_method
 
     def register_instance(
@@ -293,6 +295,13 @@ class Container:
         child._init_hooks = dict(self._init_hooks)
         child._destroy_hooks = dict(self._destroy_hooks)
         return child
+
+    @staticmethod
+    def _check_lifecycle_method(target: type, method_name: str, kind: str) -> None:
+        """Raise if the named method does not exist on the class."""
+        if not hasattr(target, method_name):
+            msg = f"{kind} '{method_name}' does not exist on {target.__name__}"
+            raise ValueError(msg)
 
     def _check_scope(self, scope: Scope) -> None:
         """Raise if the scope has no registered manager."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -66,6 +66,16 @@ class TestContainerRegistration:
         with pytest.raises(ValueError, match="request"):
             c.register_factory(Repository, return_type=Repository, scope=Scope.REQUEST)
 
+    def test_register_rejects_invalid_init_method(self) -> None:
+        c = Container()
+        with pytest.raises(ValueError, match=r"init_method.*nonexistent.*Repository"):
+            c.register(Repository, init_method="nonexistent")
+
+    def test_register_rejects_invalid_destroy_method(self) -> None:
+        c = Container()
+        with pytest.raises(ValueError, match=r"destroy_method.*nonexistent"):
+            c.register(Repository, destroy_method="nonexistent")
+
 
 class TestContainerResolution:
     def test_singleton_scope(self) -> None:


### PR DESCRIPTION
## Summary
- `register()` now validates that `init_method` and `destroy_method` exist on the class via `hasattr`
- Raises `ValueError` immediately with a clear message instead of `AttributeError` at resolution time

## Test plan
- [x] Invalid `init_method` raises `ValueError` at registration
- [x] Invalid `destroy_method` raises `ValueError` at registration
- [x] Valid lifecycle methods still work (existing tests)
- [x] All 150 tests pass

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)