### PR TITLE
Filter list dependencies by qualifier

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -176,10 +176,12 @@ class Container:
         """Resolve a single instance of the given type."""
         return self._resolve(type_, qualifier)
 
-    def get_all[T](self, type_: type[T]) -> list[T]:
+    def get_all[T](self, type_: type[T], qualifier: str | None = None) -> list[T]:
         """Resolve all registered implementations of the given type."""
         results: list[T] = []
         for (reg_type, qual), node in self._registrations.items():
+            if qualifier is not None and qual != qualifier:
+                continue
             if reg_type is type_ or (
                 isinstance(reg_type, type) and issubclass(reg_type, type_)
             ):
@@ -231,7 +233,7 @@ class Container:
     ) -> None:
         """Resolve a single dependency into kwargs."""
         if dep.is_list:
-            kwargs[dep.name] = self.get_all(dep.required_type)
+            kwargs[dep.name] = self.get_all(dep.required_type, dep.qualifier)
         elif dep.optional or dep.has_default:
             dep_key = (dep.required_type, dep.qualifier)
             if dep_key in self._registrations:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,8 +1,9 @@
 import types
+from typing import Annotated
 
 import pytest
 
-from uncoiled import Container, DependencyResolutionError, Scope, component
+from uncoiled import Container, DependencyResolutionError, Qualifier, Scope, component
 
 
 class Repository:
@@ -167,6 +168,42 @@ class TestContainerResolution:
         results = c.get_all(Repository)
         expected_count = 2
         assert len(results) == expected_count
+
+    def test_get_all_with_qualifier(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        class RepoB(Repository):
+            pass
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="a")
+        c.register(RepoB, provides=Repository, qualifier="b")
+        results = c.get_all(Repository, qualifier="a")
+        assert len(results) == 1
+        assert isinstance(results[0], RepoA)
+
+    def test_list_dependency_with_qualifier(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        class RepoB(Repository):
+            pass
+
+        class FilteredService:
+            def __init__(
+                self,
+                repos: Annotated[list[Repository], Qualifier("a")],
+            ) -> None:
+                self.repos = repos
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="a")
+        c.register(RepoB, provides=Repository, qualifier="b")
+        c.register(FilteredService)
+        svc = c.get(FilteredService)
+        assert len(svc.repos) == 1
+        assert isinstance(svc.repos[0], RepoA)
 
 
 class TestContainerValidation:


### PR DESCRIPTION
## Summary
- `get_all()` now accepts an optional `qualifier` parameter to filter results
- `_resolve_dependency` passes `dep.qualifier` to `get_all()` for list dependencies
- When no qualifier is specified, behavior is unchanged (returns all implementations)

## Test plan
- [x] `get_all` with qualifier returns only matching registrations
- [x] List dependency with `Annotated[list[T], Qualifier("x")]` resolves only matching
- [x] Existing `get_all` and list dependency tests still pass (no qualifier = all)
- [x] All 150 tests pass

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)