### PR TITLE
Add RequestScope backed by contextvars

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -20,7 +20,7 @@ from ._inspection import DependencySpec, inspect_dependencies
 from ._lifecycle import async_call_destroy, async_call_init, call_destroy, call_init
 from ._pytest import Inject
 from ._qualifiers import Qualifier
-from ._scope import ScopeManager, SingletonScope, TransientScope
+from ._scope import RequestScope, ScopeManager, SingletonScope, TransientScope
 from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
 
 __all__ = [
@@ -41,6 +41,7 @@ __all__ = [
     "Inject",
     "LayeredSource",
     "Qualifier",
+    "RequestScope",
     "ResolutionFailure",
     "Scope",
     "ScopeManager",

--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Self
 from ._graph import ComponentNode, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
 from ._lifecycle import call_destroy, call_init
-from ._scope import SingletonScope, TransientScope
+from ._scope import RequestScope, SingletonScope, TransientScope
 from ._types import Scope
 
 if TYPE_CHECKING:
@@ -33,6 +33,7 @@ class Container:
         self._scopes: dict[Scope, ScopeManager] = {
             Scope.SINGLETON: SingletonScope(),
             Scope.TRANSIENT: TransientScope(),
+            Scope.REQUEST: RequestScope(),
         }
         self._instances: list[object] = []
         self._destroy_hooks: dict[type, str | None] = {}
@@ -289,6 +290,11 @@ class Container:
             # Restore original cached instance
             if old_cached is not None:
                 singleton.put(type_, old_cached, qualifier)
+
+    def request_context(self) -> contextlib.AbstractContextManager[None]:
+        """Enter a new request scope context."""
+        scope = self._scopes[Scope.REQUEST]
+        return scope.context()  # type: ignore[union-attr]
 
     def fork(self) -> Container:
         """Create a child container with shared registrations."""

--- a/src/uncoiled/_scope.py
+++ b/src/uncoiled/_scope.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+import contextlib
+import contextvars
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from ._types import Scope
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @runtime_checkable
@@ -94,3 +99,53 @@ class TransientScope:
 
     def clear(self) -> None:
         """No-op (nothing to clear)."""
+
+
+class RequestScope:
+    """Scope that caches instances per request context via contextvars."""
+
+    def __init__(self) -> None:
+        self._var: contextvars.ContextVar[dict[tuple[type, str | None], object]] = (
+            contextvars.ContextVar("_uncoiled_request_scope")
+        )
+
+    @property
+    def scope(self) -> Scope:
+        """Return the scope type."""
+        return Scope.REQUEST
+
+    def get[T](self, key: type[T], qualifier: str | None = None) -> T | None:
+        """Return the cached instance for the current context, or None."""
+        instances = self._var.get(None)
+        if instances is None:
+            return None
+        return instances.get((key, qualifier))  # type: ignore[return-value]
+
+    def put[T](self, key: type[T], instance: T, qualifier: str | None = None) -> None:
+        """Cache the instance in the current request context."""
+        instances = self._var.get(None)
+        if instances is None:
+            msg = "No active request context"
+            raise LookupError(msg)
+        instances[(key, qualifier)] = instance
+
+    def remove(self, key: type, qualifier: str | None = None) -> None:
+        """Remove a cached instance from the current context."""
+        instances = self._var.get(None)
+        if instances is not None:
+            instances.pop((key, qualifier), None)
+
+    def clear(self) -> None:
+        """Clear all instances in the current context."""
+        instances = self._var.get(None)
+        if instances is not None:
+            instances.clear()
+
+    @contextlib.contextmanager
+    def context(self) -> Iterator[None]:
+        """Enter a new request context."""
+        token = self._var.set({})
+        try:
+            yield
+        finally:
+            self._var.reset(token)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -57,16 +57,6 @@ class TestContainerRegistration:
         with pytest.raises(DependencyResolutionError):
             c.validate()
 
-    def test_register_rejects_unsupported_scope(self) -> None:
-        c = Container()
-        with pytest.raises(ValueError, match="request"):
-            c.register(Repository, scope=Scope.REQUEST)
-
-    def test_register_factory_rejects_unsupported_scope(self) -> None:
-        c = Container()
-        with pytest.raises(ValueError, match="request"):
-            c.register_factory(Repository, return_type=Repository, scope=Scope.REQUEST)
-
     def test_register_rejects_invalid_init_method(self) -> None:
         c = Container()
         with pytest.raises(ValueError, match=r"init_method.*nonexistent.*Repository"):
@@ -525,6 +515,31 @@ class TestContainerFork:
         child.register(MockRepo, provides=Repository)
         assert isinstance(child.get(Repository), MockRepo)
         assert not isinstance(c.get(Repository), MockRepo)
+
+
+class TestRequestScope:
+    def test_same_instance_within_context(self) -> None:
+        c = Container()
+        c.register(Repository, scope=Scope.REQUEST)
+        with c.request_context():
+            first = c.get(Repository)
+            second = c.get(Repository)
+            assert first is second
+
+    def test_different_instances_across_contexts(self) -> None:
+        c = Container()
+        c.register(Repository, scope=Scope.REQUEST)
+        with c.request_context():
+            first = c.get(Repository)
+        with c.request_context():
+            second = c.get(Repository)
+        assert first is not second
+
+    def test_resolve_outside_context_raises(self) -> None:
+        c = Container()
+        c.register(Repository, scope=Scope.REQUEST)
+        with pytest.raises(LookupError, match="request context"):
+            c.get(Repository)
 
 
 class TestContainerScan:

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,4 +1,8 @@
-from uncoiled import Scope, ScopeManager, SingletonScope, TransientScope
+import contextvars
+
+import pytest
+
+from uncoiled import RequestScope, Scope, ScopeManager, SingletonScope, TransientScope
 
 
 class TestSingletonScope:
@@ -52,3 +56,62 @@ class TestTransientScope:
 
     def test_conforms_to_protocol(self) -> None:
         assert isinstance(TransientScope(), ScopeManager)
+
+
+class TestRequestScope:
+    def test_scope_type(self) -> None:
+        assert RequestScope().scope is Scope.REQUEST
+
+    def test_conforms_to_protocol(self) -> None:
+        assert isinstance(RequestScope(), ScopeManager)
+
+    def test_get_returns_none_outside_context(self) -> None:
+        scope = RequestScope()
+        assert scope.get(str) is None
+
+    def test_put_raises_outside_context(self) -> None:
+        scope = RequestScope()
+        with pytest.raises(LookupError, match="request context"):
+            scope.put(str, "hello")
+
+    def test_put_and_get_within_context(self) -> None:
+        scope = RequestScope()
+        with scope.context():
+            scope.put(str, "hello")
+            assert scope.get(str) == "hello"
+
+    def test_qualifier_isolation(self) -> None:
+        scope = RequestScope()
+        with scope.context():
+            scope.put(str, "default")
+            scope.put(str, "primary", qualifier="primary")
+            assert scope.get(str) == "default"
+            assert scope.get(str, qualifier="primary") == "primary"
+
+    def test_clear(self) -> None:
+        scope = RequestScope()
+        with scope.context():
+            scope.put(str, "hello")
+            scope.clear()
+            assert scope.get(str) is None
+
+    def test_context_exit_cleans_up(self) -> None:
+        scope = RequestScope()
+        with scope.context():
+            scope.put(str, "hello")
+        assert scope.get(str) is None
+
+    def test_context_isolation(self) -> None:
+        scope = RequestScope()
+        results: list[str] = []
+
+        def run_in_context(value: str) -> None:
+            with scope.context():
+                scope.put(str, value)
+                results.append(scope.get(str))  # type: ignore[arg-type]
+
+        ctx1 = contextvars.copy_context()
+        ctx2 = contextvars.copy_context()
+        ctx1.run(run_in_context, "first")
+        ctx2.run(run_in_context, "second")
+        assert results == ["first", "second"]


### PR DESCRIPTION
## Summary
- New `RequestScope` class in `_scope.py` — caches instances per request context using `contextvars.ContextVar`
- `scope.context()` context manager enters/exits a request scope
- `Container.request_context()` convenience method delegates to the `RequestScope`
- `Scope.REQUEST` is now fully supported — removed the rejection tests
- `RequestScope` exported from `uncoiled` package

## Test plan
- [x] Scope type returns `Scope.REQUEST`
- [x] Conforms to `ScopeManager` protocol
- [x] `get()` returns `None` outside context
- [x] `put()` raises `LookupError` outside context
- [x] `put`/`get` work within context
- [x] Qualifier isolation within context
- [x] `clear()` within context
- [x] Context exit cleans up
- [x] Separate `contextvars.copy_context()` runs are isolated
- [x] Container: same instance within `request_context()`
- [x] Container: different instances across `request_context()` blocks
- [x] Container: resolve outside context raises `LookupError`
- [x] All 167 tests pass

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)