### PR TITLE
Add async lifecycle methods to Container

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Self
 
 from ._graph import ComponentNode, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
-from ._lifecycle import call_destroy, call_init
+from ._lifecycle import async_call_destroy, async_call_init, call_destroy, call_init
 from ._scope import RequestScope, SingletonScope, TransientScope
 from ._types import Scope
 
@@ -158,6 +158,18 @@ class Container:
                 self._resolve(node.provides, key[1])
         self._started = True
 
+    async def astart(self) -> None:
+        """Validate the graph and instantiate all singletons (async)."""
+        self.validate()
+        singleton = self._scopes[Scope.SINGLETON]
+        for key, node in self._registrations.items():
+            if (
+                node.scope is Scope.SINGLETON
+                and singleton.get(node.provides, key[1]) is None
+            ):
+                await self._aresolve(node.provides, key[1])
+        self._started = True
+
     def close(self) -> None:
         """Destroy instances in reverse creation order."""
         errors: list[Exception] = []
@@ -165,6 +177,23 @@ class Container:
             try:
                 destroy_method = self._destroy_hooks.get(type(instance))
                 call_destroy(instance, destroy_method)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+        self._instances.clear()
+        for scope_manager in self._scopes.values():
+            scope_manager.clear()
+        self._started = False
+        if errors:
+            msg = "errors during container close"
+            raise ExceptionGroup(msg, errors)
+
+    async def aclose(self) -> None:
+        """Destroy instances in reverse creation order (async)."""
+        errors: list[Exception] = []
+        for instance in reversed(self._instances):
+            try:
+                destroy_method = self._destroy_hooks.get(type(instance))
+                await async_call_destroy(instance, destroy_method)
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
         self._instances.clear()
@@ -215,6 +244,33 @@ class Container:
         if node.scope is not Scope.TRANSIENT or node.impl in self._destroy_hooks:
             self._instances.append(instance)
         call_init(instance, self._init_hooks.get(node.impl))
+
+        return instance  # type: ignore[return-value]
+
+    async def _aresolve[T](self, type_: type[T], qualifier: str | None = None) -> T:
+        """Resolve a type from the container (async)."""
+        key = (type_, qualifier)
+        node = self._registrations.get(key)
+        if node is None:
+            msg = f"No component registered for type {type_.__name__}"
+            if qualifier:
+                msg += f" with qualifier '{qualifier}'"
+            raise LookupError(msg)
+
+        scope_manager = self._scopes.get(node.scope)
+        if scope_manager:
+            cached = scope_manager.get(type_, qualifier)
+            if cached is not None:
+                return cached
+
+        instance = self._create_instance(node)
+
+        if scope_manager:
+            scope_manager.put(type_, instance, qualifier)
+
+        if node.scope is not Scope.TRANSIENT or node.impl in self._destroy_hooks:
+            self._instances.append(instance)
+        await async_call_init(instance, self._init_hooks.get(node.impl))
 
         return instance  # type: ignore[return-value]
 
@@ -325,3 +381,12 @@ class Container:
     def __exit__(self, *_args: object) -> None:
         """Close the container."""
         self.close()
+
+    async def __aenter__(self) -> Self:
+        """Start the container as an async context manager."""
+        await self.astart()
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        """Close the container asynchronously."""
+        await self.aclose()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -260,6 +260,79 @@ class TestContainerLifecycle:
             repo = c.get(Repository)
             assert isinstance(repo, Repository)
 
+    @pytest.mark.anyio
+    async def test_async_context_manager(self) -> None:
+        c = Container()
+        c.register(Repository)
+        async with c:
+            repo = c.get(Repository)
+            assert isinstance(repo, Repository)
+
+    @pytest.mark.anyio
+    async def test_astart_calls_async_init(self) -> None:
+        class Service:
+            started = False
+
+            async def start(self) -> None:
+                self.started = True
+
+        c = Container()
+        c.register(Service, init_method="start")
+        await c.astart()
+        assert c.get(Service).started
+
+    @pytest.mark.anyio
+    async def test_aclose_calls_async_destroy(self) -> None:
+        class Resource:
+            closed = False
+
+            async def shutdown(self) -> None:
+                self.closed = True
+
+        c = Container()
+        c.register(Resource, destroy_method="shutdown")
+        await c.astart()
+        res = c.get(Resource)
+        await c.aclose()
+        assert res.closed
+
+    @pytest.mark.anyio
+    async def test_aclose_calls_async_disposable(self) -> None:
+        class Resource:
+            closed = False
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        c = Container()
+        c.register(Resource)
+        await c.astart()
+        res = c.get(Resource)
+        await c.aclose()
+        assert res.closed
+
+    @pytest.mark.anyio
+    async def test_aclose_continues_on_error(self) -> None:
+        class FailResource:
+            async def aclose(self) -> None:
+                msg = "fail"
+                raise RuntimeError(msg)
+
+        class GoodResource:
+            closed = False
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        c = Container()
+        c.register(GoodResource)
+        c.register(FailResource)
+        await c.astart()
+        good = c.get(GoodResource)
+        with pytest.raises(ExceptionGroup):
+            await c.aclose()
+        assert good.closed
+
     def test_register_instance_destroy_method(self) -> None:
         class Resource:
             closed = False


### PR DESCRIPTION
## Summary
- `astart()` — async variant of `start()`, uses `async_call_init` for async init methods
- `aclose()` — async variant of `close()`, uses `async_call_destroy` supporting `AsyncDisposable`
- `__aenter__` / `__aexit__` — async context manager (`async with container:`)
- `_aresolve()` — internal async resolution with async init hook support

## Test plan
- [x] `async with container` starts and closes
- [x] `astart()` calls async init methods
- [x] `aclose()` calls async destroy methods
- [x] `aclose()` calls `AsyncDisposable.aclose()`
- [x] `aclose()` continues on error, raises `ExceptionGroup`
- [x] All 189 tests pass (asyncio + trio backends)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)