### PR TITLE
Add tests for mutation testing gaps

### DIFF
--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -5,6 +5,9 @@ import pytest
 
 from uncoiled import DictSource, bind_config, config_properties
 
+FALSY_VALUES = ["false", "0", "no", "off", "False", "FALSE", "No", "OFF"]
+TRUTHY_VALUES = ["true", "1", "yes", "on", "True", "TRUE", "Yes", "ON"]
+
 MYSQL_PORT = 3306
 POSTGRES_PORT = 5432
 
@@ -62,6 +65,23 @@ class TestConfigProperties:
         source = DictSource({"fs.root": "/opt/data"})
         config = bind_config(FsConfig, source)
         assert config.root == Path("/opt/data")
+
+    @pytest.mark.parametrize("value", FALSY_VALUES)
+    def test_bool_coercion_falsy(self, value: str) -> None:
+        source = DictSource({"app.name": "test", "app.debug": value})
+        config = bind_config(AppConfig, source)
+        assert config.debug is False
+
+    @pytest.mark.parametrize("value", TRUTHY_VALUES)
+    def test_bool_coercion_truthy(self, value: str) -> None:
+        source = DictSource({"app.name": "test", "app.debug": value})
+        config = bind_config(AppConfig, source)
+        assert config.debug is True
+
+    def test_bool_coercion_invalid_raises(self) -> None:
+        source = DictSource({"app.name": "test", "app.debug": "maybe"})
+        with pytest.raises(ValueError, match="Cannot coerce"):
+            bind_config(AppConfig, source)
 
     def test_missing_required_raises(self) -> None:
         @config_properties("svc")

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -627,3 +627,160 @@ class TestContainerScan:
         c = Container()
         c.scan(mod)
         assert isinstance(c.get(ScanService), ScanService)
+
+    def test_scan_walks_subpackages(self, tmp_path: pytest.TempPathFactory) -> None:
+        """scan() should discover components in submodules of a package."""
+        import sys  # noqa: PLC0415
+
+        # Create a real package on disk so pkgutil.walk_packages works
+        pkg_dir = tmp_path / "test_scan_pkg"  # type: ignore[operator]
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "sub.py").write_text(
+            "from uncoiled import component\n\n"
+            "@component\n"
+            "class SubComponent:\n"
+            "    pass\n",
+        )
+
+        sys.path.insert(0, str(tmp_path))
+        try:
+            c = Container()
+            c.scan("test_scan_pkg")
+            # Import the class to use as a lookup key
+            from test_scan_pkg.sub import SubComponent  # type: ignore[import-not-found]  # noqa: PLC0415, I001
+
+            assert isinstance(c.get(SubComponent), SubComponent)
+        finally:
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("test_scan_pkg", None)
+            sys.modules.pop("test_scan_pkg.sub", None)
+
+
+class TestContainerLifecycleState:
+    def test_started_false_before_start(self) -> None:
+        c = Container()
+        c.register(Repository)
+        assert c._started is False  # noqa: SLF001
+
+    def test_started_true_after_start(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.start()
+        assert c._started is True  # noqa: SLF001
+
+    def test_started_false_after_close(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.start()
+        c.close()
+        assert c._started is False  # noqa: SLF001
+
+    @pytest.mark.anyio
+    async def test_started_true_after_astart(self) -> None:
+        c = Container()
+        c.register(Repository)
+        await c.astart()
+        assert c._started is True  # noqa: SLF001
+
+    @pytest.mark.anyio
+    async def test_started_false_after_aclose(self) -> None:
+        c = Container()
+        c.register(Repository)
+        await c.astart()
+        await c.aclose()
+        assert c._started is False  # noqa: SLF001
+
+    def test_start_calls_init_hooks_for_singletons(self) -> None:
+        class Service:
+            started = False
+
+            def initialize(self) -> None:
+                self.started = True
+
+        c = Container()
+        c.register(Service, init_method="initialize")
+        c.start()
+        assert c.get(Service).started
+
+    def test_close_clears_scope_caches(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.start()
+        repo = c.get(Repository)
+        assert repo is not None
+        c.close()
+        # After close, the singleton cache should be cleared
+        singleton = c._scopes[Scope.SINGLETON]  # noqa: SLF001
+        assert singleton.get(Repository) is None
+
+    @pytest.mark.anyio
+    async def test_aclose_clears_scope_caches(self) -> None:
+        c = Container()
+        c.register(Repository)
+        await c.astart()
+        c.get(Repository)
+        await c.aclose()
+        singleton = c._scopes[Scope.SINGLETON]  # noqa: SLF001
+        assert singleton.get(Repository) is None
+
+    @pytest.mark.anyio
+    async def test_astart_calls_init_hooks_for_singletons(self) -> None:
+        class Service:
+            started = False
+
+            async def initialize(self) -> None:
+                self.started = True
+
+        c = Container()
+        c.register(Service, init_method="initialize")
+        await c.astart()
+        assert c.get(Service).started
+
+
+class TestGetAllQualifierFiltering:
+    def test_get_all_with_qualifier_skips_non_matching(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        class RepoB(Repository):
+            pass
+
+        class RepoC(Repository):
+            pass
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="a")
+        c.register(RepoB, provides=Repository, qualifier="b")
+        c.register(RepoC, provides=Repository, qualifier="c")
+        results = c.get_all(Repository, qualifier="b")
+        assert len(results) == 1
+        assert isinstance(results[0], RepoB)
+
+    def test_get_all_without_qualifier_returns_all(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        class RepoB(Repository):
+            pass
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="a")
+        c.register(RepoB, provides=Repository, qualifier="b")
+        expected = 2
+        assert len(c.get_all(Repository)) == expected
+
+    def test_resolve_missing_with_qualifier_includes_qualifier_in_error(self) -> None:
+        c = Container()
+        with pytest.raises(LookupError, match="primary"):
+            c.get(Repository, qualifier="primary")
+
+    @pytest.mark.anyio
+    async def test_aresolve_caches_singleton(self) -> None:
+        """Async resolution should cache singletons, returning same instance."""
+        c = Container()
+        c.register(Repository)
+        await c.astart()
+        first = c.get(Repository)
+        second = c.get(Repository)
+        assert first is second

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 import pytest
 
 from uncoiled import (
     ComponentNode,
     DependencyResolutionError,
     FailureKind,
+    Qualifier,
     build_graph,
     validate_graph,
 )
@@ -106,6 +109,128 @@ class TestBuildGraph:
         failures = build_graph(registrations)
         expected = 2
         assert len(failures) == expected
+
+    def test_list_dep_does_not_block_subsequent_deps(self) -> None:
+        """A list dep followed by a required dep must still validate the latter."""
+
+        class Aggregator:
+            def __init__(self, repos: list[Repository], svc: UserService) -> None:
+                self.repos = repos
+                self.svc = svc
+
+        registrations = _make_registrations(
+            ComponentNode(impl=Aggregator, provides=Aggregator),
+        )
+        failures = build_graph(registrations)
+        assert len(failures) == 1
+        assert failures[0].kind is FailureKind.MISSING
+        assert "UserService" in failures[0].message
+
+    def test_optional_dep_does_not_block_subsequent_deps(self) -> None:
+        """An optional dep followed by a required dep must still validate the latter."""
+
+        class Combo:
+            def __init__(
+                self,
+                opt: Repository | None = None,
+                required: UserService = ...,  # type: ignore[assignment]
+            ) -> None:
+                self.opt = opt
+                self.required = required
+
+        registrations = _make_registrations(
+            ComponentNode(impl=UserService, provides=UserService),
+            ComponentNode(impl=Combo, provides=Combo),
+        )
+        # UserService itself needs Repository which is missing
+        failures = build_graph(registrations)
+        assert any(f.kind is FailureKind.MISSING for f in failures)
+        assert any("Repository" in f.message for f in failures)
+
+    def test_missing_qualified_dep_includes_qualifier_in_message(self) -> None:
+        class QualService:
+            def __init__(
+                self,
+                repo: Annotated[Repository, Qualifier("primary")],
+            ) -> None:
+                self.repo = repo
+
+        registrations = _make_registrations(
+            ComponentNode(impl=QualService, provides=QualService),
+        )
+        failures = build_graph(registrations)
+        assert len(failures) == 1
+        assert "primary" in failures[0].message
+        assert "primary" in failures[0].suggestion
+
+    def test_diamond_dependency_validates(self) -> None:
+        """A diamond graph (A->B, A->C, B->D, C->D) should validate."""
+
+        class D:
+            pass
+
+        class B:
+            def __init__(self, d: D) -> None:
+                self.d = d
+
+        class C:
+            def __init__(self, d: D) -> None:
+                self.d = d
+
+        class A:
+            def __init__(self, b: B, c: C) -> None:
+                self.b = b
+                self.c = c
+
+        registrations = _make_registrations(
+            ComponentNode(impl=D, provides=D),
+            ComponentNode(impl=B, provides=B),
+            ComponentNode(impl=C, provides=C),
+            ComponentNode(impl=A, provides=A),
+        )
+        assert build_graph(registrations) == []
+
+    def test_cycle_detection_reports_cycle_nodes(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=CycleA, provides=CycleA),
+            ComponentNode(impl=CycleB, provides=CycleB),
+        )
+        failures = build_graph(registrations)
+        circular = [f for f in failures if f.kind is FailureKind.CIRCULAR]
+        assert len(circular) == 1
+        assert "CycleA" in circular[0].message
+        assert "CycleB" in circular[0].message
+
+    def test_no_false_positive_cycle_in_large_graph(self) -> None:
+        """A long chain A->B->C->D->E should not falsely detect a cycle."""
+
+        class E:
+            pass
+
+        class D:
+            def __init__(self, e: E) -> None:
+                self.e = e
+
+        class C:
+            def __init__(self, d: D) -> None:
+                self.d = d
+
+        class B:
+            def __init__(self, c: C) -> None:
+                self.c = c
+
+        class A:
+            def __init__(self, b: B) -> None:
+                self.b = b
+
+        registrations = _make_registrations(
+            ComponentNode(impl=E, provides=E),
+            ComponentNode(impl=D, provides=D),
+            ComponentNode(impl=C, provides=C),
+            ComponentNode(impl=B, provides=B),
+            ComponentNode(impl=A, provides=A),
+        )
+        assert build_graph(registrations) == []
 
 
 class TestValidateGraph:

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Optional, Union
 
 from uncoiled import DependencySpec, Qualifier, inspect_dependencies
 
@@ -118,3 +118,119 @@ class TestInspectDependencies:
         assert specs[1].has_default
         assert specs[2].name == "other"
         assert specs[2].optional
+
+    def test_unannotated_param_does_not_block_later_params(self) -> None:
+        """Skipping an unannotated param should still process subsequent ones."""
+
+        class Mixed:
+            def __init__(self, x, repo: Repository, name: str = "hi") -> None:  # noqa: ANN001
+                self.x = x
+                self.repo = repo
+                self.name = name
+
+        specs = inspect_dependencies(Mixed)
+        expected = 2
+        assert len(specs) == expected
+        assert specs[0].name == "repo"
+        assert specs[1].name == "name"
+
+    def test_annotated_with_multiple_qualifiers_uses_first(self) -> None:
+        """When multiple Qualifiers are in Annotated metadata, the first wins."""
+
+        class MultiQual:
+            def __init__(
+                self,
+                repo: Annotated[Repository, Qualifier("first"), Qualifier("second")],
+            ) -> None:
+                self.repo = repo
+
+        specs = inspect_dependencies(MultiQual)
+        assert len(specs) == 1
+        assert specs[0].qualifier == "first"
+
+    def test_optional_dep_marked_optional(self) -> None:
+        class Svc:
+            def __init__(self, repo: Repository | None) -> None:
+                self.repo = repo
+
+        specs = inspect_dependencies(Svc)
+        assert len(specs) == 1
+        assert specs[0].optional is True
+
+    def test_optional_typing_form(self) -> None:
+        """typing.Optional[T] should be handled the same as T | None."""
+
+        class Svc:
+            def __init__(self, repo: Optional[Repository]) -> None:  # noqa: UP045
+                self.repo = repo
+
+        specs = inspect_dependencies(Svc)
+        assert len(specs) == 1
+        assert specs[0].required_type is Repository
+        assert specs[0].optional is True
+
+    def test_multi_union_not_unwrapped(self) -> None:
+        """Union[A, B] (no None) should not be treated as optional."""
+
+        class Svc:
+            def __init__(self, thing: Union[Repository, UserService]) -> None:  # noqa: UP007
+                self.thing = thing
+
+        specs = inspect_dependencies(Svc)
+        assert specs == []
+
+    def test_three_arg_union_with_none_not_unwrapped(self) -> None:
+        """Union[A, B, None] should not be unwrapped to a single type."""
+
+        class Svc:
+            def __init__(
+                self,
+                thing: Union[Repository, UserService, None],  # noqa: UP007
+            ) -> None:
+                self.thing = thing
+
+        specs = inspect_dependencies(Svc)
+        assert specs == []
+
+    def test_annotated_optional_with_qualifier(self) -> None:
+        """Annotated[Optional[T], Qualifier] should be optional with qualifier."""
+
+        class Svc:
+            def __init__(
+                self,
+                repo: Annotated[Repository | None, Qualifier("pg")],
+            ) -> None:
+                self.repo = repo
+
+        specs = inspect_dependencies(Svc)
+        assert len(specs) == 1
+        assert specs[0].required_type is Repository
+        assert specs[0].optional is True
+        assert specs[0].qualifier == "pg"
+
+    def test_annotated_list_extracts_inner_type(self) -> None:
+        """Annotated[list[T], Qualifier] should extract T."""
+
+        class Svc:
+            def __init__(
+                self,
+                repos: Annotated[list[Repository], Qualifier("all")],
+            ) -> None:
+                self.repos = repos
+
+        specs = inspect_dependencies(Svc)
+        assert len(specs) == 1
+        assert specs[0].required_type is Repository
+        assert specs[0].is_list is True
+        assert specs[0].qualifier == "all"
+
+    def test_function_inspection(self) -> None:
+        def factory(repo: Repository, name: str = "x") -> UserService:
+            _ = name
+            return UserService(repo)
+
+        specs = inspect_dependencies(factory)
+        expected = 2
+        assert len(specs) == expected
+        assert specs[0].name == "repo"
+        assert specs[1].has_default is True


### PR DESCRIPTION
## Summary

- Adds tests to kill surviving mutants identified by Cosmic Ray mutation testing
- Covers 8 high-priority issues (#66–#73) across core modules
- Brings `_graph.py` to 100% coverage; overall coverage remains at 97%

### Tests added per issue

- **#66** — Graph building: list/optional deps don't block subsequent deps, qualifier in error messages
- **#67** — Topological sort: diamond graph, cycle detection with node names, long chains without false positives
- **#68** — `Container.scan_packages`: real subpackage scanning via temp directory
- **#69** — Lifecycle state: `_started` flag transitions, init hooks during start, scope cache clearing on close (sync + async)
- **#70** — `get_all` qualifier filtering: multiple qualifiers, unqualified returns all, qualifier in error messages
- **#71** — Async resolution: singleton caching through `_aresolve` path
- **#72** — Parameter inspection: unannotated params, multiple qualifiers (first wins), Optional, Union variants, Annotated+list, function inspection
- **#73** — Bool parsing: parametrized tests for all falsy/truthy values and invalid input

## Test plan

- [x] All 240 tests pass
- [x] `uv run ty check` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes

Closes #66, closes #67, closes #68, closes #69, closes #70, closes #71, closes #72, closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)