### PR TITLE
Add provides parameter to @component and Inject[T] shorthand

### DIFF
--- a/src/uncoiled/_component.py
+++ b/src/uncoiled/_component.py
@@ -14,6 +14,7 @@ class ComponentMetadata:
 
     scope: Scope = Scope.SINGLETON
     qualifier: str | None = None
+    provides: type | None = None
 
 
 @overload
@@ -25,6 +26,7 @@ def component(
     *,
     scope: Scope = ...,
     qualifier: str | None = ...,
+    provides: type | None = ...,
 ) -> _ComponentDecorator: ...
 
 
@@ -34,6 +36,7 @@ def component(
     *,
     scope: Scope = Scope.SINGLETON,
     qualifier: str | None = None,
+    provides: type | None = None,
 ) -> type | _ComponentDecorator:
     """Mark a class as a DI-managed component.
 
@@ -45,10 +48,13 @@ def component(
         @component(scope=Scope.TRANSIENT, qualifier="special")
         class SpecialService: ...
 
+        @component(provides=Repository)
+        class PostgresRepository: ...
+
     Attaches ``ComponentMetadata`` as a ``__uncoiled__`` attribute.
     Does not modify class behaviour.
     """
-    meta = ComponentMetadata(scope=scope, qualifier=qualifier)
+    meta = ComponentMetadata(scope=scope, qualifier=qualifier, provides=provides)
 
     if cls is not None:
         cls.__uncoiled__ = meta  # ty: ignore[unresolved-attribute]

--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -139,7 +139,12 @@ class Container:
         for _name, obj in inspect.getmembers(mod, inspect.isclass):
             meta: ComponentMetadata | None = getattr(obj, "__uncoiled__", None)
             if meta is not None:
-                self.register(obj, scope=meta.scope, qualifier=meta.qualifier)
+                self.register(
+                    obj,
+                    scope=meta.scope,
+                    qualifier=meta.qualifier,
+                    provides=meta.provides,
+                )
 
     def validate(self) -> None:
         """Validate the dependency graph eagerly."""

--- a/src/uncoiled/fastapi.py
+++ b/src/uncoiled/fastapi.py
@@ -29,16 +29,28 @@ def _get_container(request: Request) -> Container:
     return container
 
 
-class _InjectMarker:
-    """Marker for ``Annotated[T, Inject]`` in FastAPI route signatures."""
+class Inject:
+    """Shorthand for injecting a dependency from the container.
 
+    Usage in route signatures::
 
-Inject = _InjectMarker()
-"""Use as ``Annotated[MyService, Inject]`` in route parameters."""
+        @app.get("/users")
+        def list_users(ctrl: Inject[UserController]) -> list[User]: ...
+
+    ``Inject[T]`` expands to ``Annotated[T, Depends(...)]`` so FastAPI
+    resolves the type from the container automatically.
+    """
+
+    def __class_getitem__(cls, type_: type) -> type:
+        """Return ``Annotated[T, Depends(...)]`` for the given type."""
+        return Annotated[type_, inject_dependency(type_)]  # type: ignore[return-value]
 
 
 def inject_dependency[T](type_: type[T]) -> T:
-    """Create a FastAPI ``Depends`` that resolves *type_* from the container."""
+    """Create a FastAPI ``Depends`` that resolves *type_* from the container.
+
+    Prefer ``Inject[T]`` in route signatures for brevity.
+    """
 
     def _resolve(
         container: Annotated[Container, Depends(_get_container)],

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -39,6 +39,23 @@ class TestComponentDecorator:
         )
         assert _get_metadata(MyService) == expected
 
+    def test_decorator_with_provides(self) -> None:
+        class Base:
+            pass
+
+        @component(provides=Base)
+        class Impl(Base):
+            pass
+
+        assert _get_metadata(Impl).provides is Base
+
+    def test_provides_defaults_to_none(self) -> None:
+        @component
+        class MyService:
+            pass
+
+        assert _get_metadata(MyService).provides is None
+
     def test_does_not_modify_class(self) -> None:
         @component
         class MyService:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -654,6 +654,21 @@ class TestContainerScan:
         c.scan(mod)
         assert isinstance(c.get(ScanService), ScanService)
 
+    def test_scan_honours_provides(self) -> None:
+        class Base:
+            pass
+
+        @component(provides=Base)
+        class Impl(Base):
+            pass
+
+        mod = types.ModuleType("test_scan_provides")
+        mod.Impl = Impl  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(Base), Impl)
+
     def test_scan_walks_subpackages(self, tmp_path: pytest.TempPathFactory) -> None:
         """scan() should discover components in submodules of a package."""
         import sys  # noqa: PLC0415

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 
 from uncoiled import Container, Scope
 from uncoiled.fastapi import (
+    Inject,
     RequestScopeMiddleware,
     configure_container,
     inject_dependency,
@@ -34,6 +35,25 @@ class TestInjectDependency:
         def index(
             repo: Annotated[Repository, inject_dependency(Repository)],
         ) -> dict:
+            return {"type": type(repo).__name__}
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"type": "Repository"}
+
+    @pytest.mark.anyio
+    async def test_inject_shorthand_resolves_from_container(self) -> None:
+        c = Container()
+        c.register(Repository)
+        app = FastAPI()
+        configure_container(app, c)
+
+        @app.get("/")
+        def index(repo: Inject[Repository]) -> dict:
             return {"type": type(repo).__name__}
 
         async with httpx.AsyncClient(


### PR DESCRIPTION
## Summary
- `@component(provides=Base)` lets `scan()` register an implementation against a base type or protocol
- `Inject[T]` expands to `Annotated[T, Depends(...)]` for terser FastAPI route signatures
- Tests for both features plus `scan()` honouring `provides`

## Test plan
- [x] New tests for `provides` on `@component` decorator
- [x] New test for `scan()` passing `provides` through
- [x] New test for `Inject[T]` shorthand in FastAPI routes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)