### PR TITLE
Rename pytest Inject to Resolve

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -19,7 +19,7 @@ from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
 from ._lifecycle import async_call_destroy, async_call_init, call_destroy, call_init
-from ._pytest import Inject
+from ._pytest import Resolve
 from ._qualifiers import Qualifier
 from ._scope import RequestScope, ScopeManager, SingletonScope, TransientScope
 from ._types import MISSING, AsyncDisposable, Disposable, Factory, Scope
@@ -39,11 +39,11 @@ __all__ = [
     "EnvSource",
     "Factory",
     "FailureKind",
-    "Inject",
     "LayeredSource",
     "Qualifier",
     "RequestScope",
     "ResolutionFailure",
+    "Resolve",
     "Scope",
     "ScopeManager",
     "SingletonScope",

--- a/src/uncoiled/_pytest.py
+++ b/src/uncoiled/_pytest.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-class Inject:
+class Resolve:
     """Function-scoped helper to resolve types from the container."""
 
     def __init__(self, container: Container) -> None:
@@ -34,9 +34,9 @@ def uncoiled_container() -> Iterator[Container]:
 
 
 @pytest.fixture
-def inject(uncoiled_container: Container) -> Inject:
+def inject(uncoiled_container: Container) -> Resolve:
     """Function-scoped fixture to resolve types from the container."""
-    return Inject(uncoiled_container)
+    return Resolve(uncoiled_container)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_example_integration.py
+++ b/tests/test_example_integration.py
@@ -16,7 +16,7 @@ import pytest
 from example.app import REQUEST_VALUES, create_app
 from example.controller import UserController
 from example.domain import TenantId, User, UserRepository
-from uncoiled import Container, Inject
+from uncoiled import Container, Resolve
 from uncoiled.fastapi import configure_container
 
 if TYPE_CHECKING:
@@ -75,7 +75,7 @@ class TestViaInject:
 
     def test_controller_uses_in_memory_repo(
         self,
-        inject: Inject,
+        inject: Resolve,
         uncoiled_container: Container,
     ) -> None:
         with uncoiled_container.request_context():
@@ -88,7 +88,7 @@ class TestViaInject:
 
     def test_get_seeded_user(
         self,
-        inject: Inject,
+        inject: Resolve,
         uncoiled_container: Container,
     ) -> None:
         with uncoiled_container.request_context():

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from uncoiled import Container, Inject
+from uncoiled import Container, Resolve
 
 
 class Repository:
@@ -11,20 +11,20 @@ class MockRepo(Repository):
     pass
 
 
-class TestInject:
+class TestResolve:
     def test_getitem_resolves_type(self) -> None:
         c = Container()
         c.register(Repository)
         c.start()
-        inject = Inject(c)
-        assert isinstance(inject[Repository], Repository)
+        resolve = Resolve(c)
+        assert isinstance(resolve[Repository], Repository)
 
     def test_getitem_raises_for_missing(self) -> None:
         c = Container()
         c.start()
-        inject = Inject(c)
+        resolve = Resolve(c)
         with pytest.raises(LookupError):
-            inject[Repository]
+            resolve[Repository]
 
 
 class TestPluginFixtures:
@@ -58,8 +58,8 @@ def uncoiled_container():
         configured_pytester.makepyfile(
             """\
 def test_inject(inject):
-    from uncoiled import Inject
-    assert isinstance(inject, Inject)
+    from uncoiled import Resolve
+    assert isinstance(inject, Resolve)
 """
         )
         result = configured_pytester.runpytest()


### PR DESCRIPTION
## Summary

- Rename `Inject` in `_pytest.py` to `Resolve` to eliminate the naming collision with `uncoiled.fastapi.Inject`
- Update `__init__.py` re-export and `__all__`
- Update all test references

Closes #97

## Test plan

- [x] All 296 tests pass
- [x] ty/ruff/format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)