### PR TITLE
Prevent lifespan from overwriting pre-configured container

### DIFF
--- a/src/uncoiled/fastapi.py
+++ b/src/uncoiled/fastapi.py
@@ -120,6 +120,14 @@ def uncoiled_lifespan(
 
     @contextlib.asynccontextmanager
     async def _lifespan(app: object) -> AsyncIterator[None]:
+        existing: Container | None = getattr(
+            getattr(app, "state", None),
+            "uncoiled_container",
+            None,
+        )
+        if existing is not None:
+            yield
+            return
         app.state.uncoiled_container = container  # ty: ignore[unresolved-attribute]
         container.start()
         try:

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -276,3 +276,23 @@ class TestUncoiledLifespan:
 
         # After exiting, lifespan closes the container
         assert res.closed
+
+    @pytest.mark.anyio
+    async def test_lifespan_preserves_preconfigured_container(self) -> None:
+        """Lifespan must not overwrite a container set by configure_container."""
+        test_container = Container()
+        test_container.register(Repository)
+
+        prod_container = Container()
+
+        app = FastAPI(lifespan=uncoiled_lifespan(prod_container))
+        configure_container(app, test_container)
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            # Trigger a request so the lifespan runs
+            await client.get("/nonexistent")
+
+        assert app.state.uncoiled_container is test_container


### PR DESCRIPTION
## Summary

- `uncoiled_lifespan()` now checks for an existing container on `app.state` before setting one — if `configure_container()` was called first, the lifespan yields without overwriting it
- Adds a test verifying the pre-configured container is preserved

Closes #99

## Test plan

- [x] New test: `test_lifespan_preserves_preconfigured_container`
- [x] All 298 tests pass
- [x] ty/ruff/format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)