### PR TITLE
Move example container setup into factory function

### DIFF
--- a/src/example/app.py
+++ b/src/example/app.py
@@ -42,15 +42,16 @@ def create_app(container: Container) -> FastAPI:
     return application
 
 
-# ── Production wiring ────────────────────────────────────────────
-#
-# 1. Bind DbConfig from environment variables (e.g. DB_URL=...).
-# 2. scan() discovers @component classes in the example package.
-# 3. create_app() adds RequestScopeMiddleware (extracts TenantId
-#    from X-Tenant-Id header) and includes the user routes.
+def create_default_app() -> FastAPI:
+    """Build the production app with env-sourced config.
 
-container = Container()
-container.register_instance(bind_config(DbConfig, EnvSource()))
-container.scan("example")
+    Container creation happens inside this function so that
+    importing the module does not trigger side effects (env var
+    reads, component scanning).  ASGI servers call this via::
 
-app = create_app(container)
+        uvicorn example.app:app --factory
+    """
+    c = Container()
+    c.register_instance(bind_config(DbConfig, EnvSource()))
+    c.scan("example")
+    return create_app(c)


### PR DESCRIPTION
## Summary

- Replace module-level `container` and `app` with a `create_default_app()` factory
- Importing `example.app` no longer triggers env var reads or component scanning
- Tests continue to use `create_app(container)` directly with their own registrations

Closes #98

## Test plan

- [x] All 296 tests pass (integration tests unaffected — they already use `create_app`)
- [x] ty/ruff/format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)