### PR TITLE
Raise on duplicate registration unless replace=True

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -52,11 +52,13 @@ class Container:
         provides: type | None = None,
         init_method: str | None = None,
         destroy_method: str | None = None,
+        replace: bool = False,
     ) -> None:
         """Register a class as a component."""
         self._check_scope(scope)
         provides = provides or cls
         key = (provides, qualifier)
+        self._check_duplicate(key, replace=replace)
         self._registrations[key] = ComponentNode(
             impl=cls,
             provides=provides,
@@ -78,10 +80,12 @@ class Container:
         type_: type | None = None,
         qualifier: str | None = None,
         destroy_method: str | None = None,
+        replace: bool = False,
     ) -> None:
         """Register a pre-constructed instance."""
         type_ = type_ or type(instance)
         key = (type_, qualifier)
+        self._check_duplicate(key, replace=replace)
         self._registrations[key] = ComponentNode(
             impl=type_,
             provides=type_,
@@ -101,10 +105,12 @@ class Container:
         qualifier: str | None = None,
         init_method: str | None = None,
         destroy_method: str | None = None,
+        replace: bool = False,
     ) -> None:
         """Register a factory callable for a type."""
         self._check_scope(scope)
         key = (return_type, qualifier)
+        self._check_duplicate(key, replace=replace)
         node = ComponentNode(
             impl=return_type,
             provides=return_type,
@@ -166,7 +172,8 @@ class Container:
 
     def _scan_module(self, mod: ModuleType) -> None:
         """Scan a single module and its submodules for components."""
-        self._register_from_module(mod)
+        seen: set[type] = set()
+        self._register_from_module(mod, seen)
 
         if hasattr(mod, "__path__"):
             for _importer, modname, _ispkg in pkgutil.walk_packages(
@@ -174,13 +181,20 @@ class Container:
                 prefix=mod.__name__ + ".",
             ):
                 submod = importlib.import_module(modname)
-                self._register_from_module(submod)
+                self._register_from_module(submod, seen)
 
-    def _register_from_module(self, mod: ModuleType) -> None:
+    def _register_from_module(
+        self,
+        mod: ModuleType,
+        seen: set[type],
+    ) -> None:
         """Register all ``@component``-decorated classes found in a module."""
         for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            if obj in seen:
+                continue
             meta: ComponentMetadata | None = getattr(obj, "__uncoiled__", None)
             if meta is not None:
+                seen.add(obj)
                 self.register(
                     obj,
                     scope=meta.scope,
@@ -380,9 +394,19 @@ class Container:
 
         # Install the replacement
         if isinstance(replacement, type):
-            self.register(replacement, provides=type_, qualifier=qualifier)
+            self.register(
+                replacement,
+                provides=type_,
+                qualifier=qualifier,
+                replace=True,
+            )
         else:
-            self.register_instance(replacement, type_=type_, qualifier=qualifier)
+            self.register_instance(
+                replacement,
+                type_=type_,
+                qualifier=qualifier,
+                replace=True,
+            )
 
         try:
             yield
@@ -418,6 +442,21 @@ class Container:
         """Raise if the named method does not exist on the class."""
         if not hasattr(target, method_name):
             msg = f"{kind} '{method_name}' does not exist on {target.__name__}"
+            raise ValueError(msg)
+
+    def _check_duplicate(
+        self,
+        key: tuple[type, str | None],
+        *,
+        replace: bool,
+    ) -> None:
+        """Raise if a registration already exists and replace is not set."""
+        if not replace and key in self._registrations:
+            type_, qualifier = key
+            msg = f"A registration for {type_.__name__} already exists"
+            if qualifier:
+                msg += f" with qualifier '{qualifier}'"
+            msg += "; pass replace=True to override"
             raise ValueError(msg)
 
     def _check_scope(self, scope: Scope) -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -58,6 +58,33 @@ class TestContainerRegistration:
         with pytest.raises(DependencyResolutionError):
             c.validate()
 
+    def test_duplicate_register_raises(self) -> None:
+        c = Container()
+        c.register(Repository)
+        with pytest.raises(ValueError, match="already exists"):
+            c.register(Repository)
+
+    def test_duplicate_register_with_replace(self) -> None:
+        class MockRepo(Repository):
+            pass
+
+        c = Container()
+        c.register(Repository)
+        c.register(MockRepo, provides=Repository, replace=True)
+        assert isinstance(c.get(Repository), MockRepo)
+
+    def test_duplicate_register_instance_raises(self) -> None:
+        c = Container()
+        c.register_instance(Repository())
+        with pytest.raises(ValueError, match="already exists"):
+            c.register_instance(Repository())
+
+    def test_duplicate_register_factory_raises(self) -> None:
+        c = Container()
+        c.register_factory(Repository, return_type=Repository)
+        with pytest.raises(ValueError, match="already exists"):
+            c.register_factory(Repository, return_type=Repository)
+
     def test_register_rejects_invalid_init_method(self) -> None:
         c = Container()
         with pytest.raises(ValueError, match=r"init_method.*nonexistent.*Repository"):
@@ -611,7 +638,7 @@ class TestContainerFork:
         c = Container()
         c.register(Repository)
         child = c.fork()
-        child.register(MockRepo, provides=Repository)
+        child.register(MockRepo, provides=Repository, replace=True)
         assert isinstance(child.get(Repository), MockRepo)
         assert not isinstance(c.get(Repository), MockRepo)
 

--- a/tests/test_example_integration.py
+++ b/tests/test_example_integration.py
@@ -53,7 +53,7 @@ def _test_app() -> FastAPI:
     """Build the app once per module so the container fixture can wire it."""
     c = Container()
     c.scan("example")
-    c.register(InMemoryUserRepository, provides=UserRepository)
+    c.register(InMemoryUserRepository, provides=UserRepository, replace=True)
     application = create_app(c)
     configure_container(
         application,


### PR DESCRIPTION
## Summary

- `register()`, `register_instance()`, and `register_factory()` now raise `ValueError` when a registration already exists for the same type/qualifier key
- Pass `replace=True` to explicitly override an existing registration
- `override()` uses `replace=True` internally (it's the scoped replacement mechanism)
- `scan()` now tracks seen classes to avoid duplicate registrations when a `@component` class is visible in multiple modules of a package

Closes #100

## Test plan

- [x] 4 new tests: duplicate raises for register/register_instance/register_factory, and replace=True works
- [x] All 300 tests pass
- [x] ty/ruff/format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)