### PR TITLE
Add EnvVar marker for injecting environment variables

### DIFF
--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -15,6 +15,7 @@ from ._config._sources import (
     YamlSource,
 )
 from ._container import Container
+from ._envvar import EnvVar
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._graph import ComponentNode, build_graph, validate_graph
 from ._inspection import DependencySpec, inspect_dependencies
@@ -37,6 +38,7 @@ __all__ = [
     "Disposable",
     "DotEnvSource",
     "EnvSource",
+    "EnvVar",
     "Factory",
     "FailureKind",
     "Inject",

--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import inspect
+import os
 import pkgutil
 from typing import TYPE_CHECKING, Self
 
@@ -23,6 +24,26 @@ if TYPE_CHECKING:
 
 
 _REQUEST_VALUE_SENTINEL = object()
+
+_BOOL_TRUE = frozenset({"1", "true", "yes", "on"})
+_BOOL_FALSE = frozenset({"0", "false", "no", "off"})
+
+
+def _coerce_env(value: str, target: type) -> object:
+    """Coerce a string environment variable to the target type."""
+    if target is str:
+        return value
+    if target is bool:
+        lower = value.lower()
+        if lower in _BOOL_TRUE:
+            return True
+        if lower in _BOOL_FALSE:
+            return False
+        msg = f"Cannot convert {value!r} to bool"
+        raise ValueError(msg)
+    if target in {int, float}:
+        return target(value)
+    return target(value)
 
 
 class Container:
@@ -344,7 +365,17 @@ class Container:
         kwargs: dict[str, object],
     ) -> None:
         """Resolve a single dependency into kwargs."""
-        if dep.is_list:
+        if dep.env_var is not None:
+            value = os.environ.get(dep.env_var)
+            if value is not None:
+                kwargs[dep.name] = _coerce_env(value, dep.required_type)
+            elif not dep.has_default:
+                msg = (
+                    f"Environment variable {dep.env_var!r} is not set"
+                    " and no default was provided"
+                )
+                raise LookupError(msg)
+        elif dep.is_list:
             kwargs[dep.name] = self.get_all(dep.required_type, dep.qualifier)
         elif dep.optional or dep.has_default:
             dep_key = (dep.required_type, dep.qualifier)

--- a/src/uncoiled/_envvar.py
+++ b/src/uncoiled/_envvar.py
@@ -1,0 +1,25 @@
+"""Environment variable injection marker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EnvVar:
+    """Marker for injecting an environment variable via ``Annotated``.
+
+    Usage::
+
+        class MyService:
+            def __init__(
+                self,
+                db_url: Annotated[str, EnvVar("DATABASE_URL")] = ":memory:",
+            ) -> None: ...
+
+    The container resolves ``EnvVar("DATABASE_URL")`` from ``os.environ``
+    at injection time, falling back to the parameter default if the
+    variable is unset.
+    """
+
+    name: str

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -52,7 +52,7 @@ def build_graph(
         for dep in node.dependencies:
             dep_key = _type_key(dep.required_type, dep.qualifier)
 
-            if dep.is_list:
+            if dep.is_list or dep.env_var is not None:
                 continue
 
             if dep_key not in registrations:

--- a/src/uncoiled/_inspection.py
+++ b/src/uncoiled/_inspection.py
@@ -7,6 +7,7 @@ import types
 from dataclasses import dataclass
 from typing import Annotated, Union, get_args, get_origin
 
+from ._envvar import EnvVar
 from ._qualifiers import Qualifier
 
 _OPTIONAL_UNION_ARGS = 2
@@ -22,6 +23,7 @@ class DependencySpec:
     is_list: bool = False
     qualifier: str | None = None
     has_default: bool = False
+    env_var: str | None = None
 
 
 def _is_optional_union(annotation: object) -> type | None:
@@ -73,6 +75,36 @@ def inspect_dependencies(target: object) -> list[DependencySpec]:
     return specs
 
 
+def _resolve_annotated(
+    name: str,
+    args: tuple[object, ...],
+    *,
+    has_default: bool,
+) -> DependencySpec | None:
+    """Resolve an ``Annotated[T, ...]`` annotation."""
+    inner = args[0]
+    qualifier = None
+    env_var = None
+    for meta in args[1:]:
+        if isinstance(meta, Qualifier) and qualifier is None:
+            qualifier = meta.name
+        elif isinstance(meta, EnvVar) and env_var is None:
+            env_var = meta.name
+    if env_var is not None:
+        return DependencySpec(
+            name=name,
+            required_type=inner if isinstance(inner, type) else type(inner),
+            has_default=has_default,
+            env_var=env_var,
+        )
+    return _resolve_annotation_with_qualifier(
+        name,
+        inner,
+        qualifier=qualifier,
+        has_default=has_default,
+    )
+
+
 def _resolve_annotation(
     name: str,
     annotation: object,
@@ -83,17 +115,9 @@ def _resolve_annotation(
     origin = get_origin(annotation)
 
     if origin is Annotated:
-        args = get_args(annotation)
-        inner = args[0]
-        qualifier = None
-        for meta in args[1:]:
-            if isinstance(meta, Qualifier):
-                qualifier = meta.name
-                break
-        return _resolve_annotation_with_qualifier(
+        return _resolve_annotated(
             name,
-            inner,
-            qualifier=qualifier,
+            get_args(annotation),
             has_default=has_default,
         )
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -4,7 +4,14 @@ from typing import Annotated
 
 import pytest
 
-from uncoiled import Container, DependencyResolutionError, Qualifier, Scope, component
+from uncoiled import (
+    Container,
+    DependencyResolutionError,
+    EnvVar,
+    Qualifier,
+    Scope,
+    component,
+)
 
 
 class Repository:
@@ -230,6 +237,94 @@ class TestContainerResolution:
         results = c.get_all(Repository)
         assert len(results) == 1
         assert isinstance(results[0], SpecialRepo)
+
+
+class TestEnvVar:
+    def test_injects_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_DB_URL", "postgres://localhost/test")
+
+        class Service:
+            def __init__(
+                self,
+                db_url: Annotated[str, EnvVar("TEST_DB_URL")],
+            ) -> None:
+                self.db_url = db_url
+
+        c = Container()
+        c.register(Service)
+        assert c.get(Service).db_url == "postgres://localhost/test"
+
+    def test_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TEST_DB_URL", raising=False)
+
+        class Service:
+            def __init__(
+                self,
+                db_url: Annotated[str, EnvVar("TEST_DB_URL")] = ":memory:",
+            ) -> None:
+                self.db_url = db_url
+
+        c = Container()
+        c.register(Service)
+        assert c.get(Service).db_url == ":memory:"
+
+    def test_raises_when_missing_no_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("TEST_REQUIRED", raising=False)
+
+        class Service:
+            def __init__(
+                self,
+                val: Annotated[str, EnvVar("TEST_REQUIRED")],
+            ) -> None:
+                self.val = val
+
+        c = Container()
+        c.register(Service)
+        with pytest.raises(LookupError, match="TEST_REQUIRED"):
+            c.get(Service)
+
+    def test_coerces_int(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_PORT", "8080")
+
+        class Service:
+            def __init__(
+                self,
+                port: Annotated[int, EnvVar("TEST_PORT")],
+            ) -> None:
+                self.port = port
+
+        c = Container()
+        c.register(Service)
+        assert c.get(Service).port == 8080
+
+    def test_coerces_bool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_DEBUG", "true")
+
+        class Service:
+            def __init__(
+                self,
+                debug: Annotated[bool, EnvVar("TEST_DEBUG")],
+            ) -> None:
+                self.debug = debug
+
+        c = Container()
+        c.register(Service)
+        assert c.get(Service).debug is True
+
+    def test_graph_validation_passes(self) -> None:
+        class Service:
+            def __init__(
+                self,
+                db_url: Annotated[str, EnvVar("DB_URL")] = ":memory:",
+            ) -> None:
+                self.db_url = db_url
+
+        c = Container()
+        c.register(Service)
+        c.validate()  # should not raise
 
 
 class TestContainerValidation:


### PR DESCRIPTION
## Summary

- New `EnvVar` marker class for injecting individual env vars via `Annotated[str, EnvVar("DB_URL")]`
- Supports type coercion: `str`, `int`, `float`, `bool` (truthy/falsy strings)
- Falls back to parameter default when env var is unset; raises `LookupError` when required and missing
- Graph validation skips `EnvVar` deps (resolved from `os.environ`, not the container)
- Extracted `_resolve_annotated` helper to keep return-statement count within lint limits

Closes #94

## Test plan

- [x] 6 new tests: injection, default fallback, missing-raises, int coercion, bool coercion, graph validation
- [x] All 302 tests pass
- [x] ty/ruff/format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)