### PR TITLE
Skip request value extraction for WebSocket connections

### DIFF
--- a/src/uncoiled/fastapi.py
+++ b/src/uncoiled/fastapi.py
@@ -93,10 +93,10 @@ class RequestScopeMiddleware:
             container.register_request_value(rv.type_, qualifier=rv.qualifier)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        """Wrap HTTP requests in a request scope context."""
+        """Wrap HTTP and WebSocket requests in a request scope context."""
         if scope["type"] in {"http", "websocket"}:
             with self._container.request_context():
-                if self._request_values:
+                if self._request_values and scope["type"] == "http":
                     request = Request(scope, receive, send)
                     for rv in self._request_values:
                         self._container.provide_request_value(

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -3,7 +3,8 @@ from typing import Annotated
 import anyio
 import httpx
 import pytest
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Request, WebSocket
+from starlette.testclient import TestClient
 
 from uncoiled import Container, Scope
 from uncoiled.fastapi import (
@@ -246,6 +247,33 @@ class TestRequestValueProvider:
 
         tenants = {r.json()["tenant"] for r in results}
         assert tenants == {"acme", "globex"}
+
+    def test_websocket_not_crashed_by_request_values(self) -> None:
+        providers = [
+            RequestValueProvider(
+                _TenantId,
+                lambda r: _TenantId(r.headers["x-tenant-id"]),
+            ),
+        ]
+        c = Container()
+        app = FastAPI()
+        app.add_middleware(
+            RequestScopeMiddleware,  # ty: ignore[invalid-argument-type]
+            container=c,
+            request_values=providers,
+        )
+        configure_container(app, c, request_values=providers)
+
+        @app.websocket("/ws")
+        async def ws_endpoint(ws: WebSocket) -> None:
+            await ws.accept()
+            await ws.send_text("hello")
+            await ws.close()
+
+        with TestClient(app).websocket_connect("/ws") as ws:
+            data = ws.receive_text()
+
+        assert data == "hello"
 
 
 class TestUncoiledLifespan:


### PR DESCRIPTION
## Summary
- `RequestScopeMiddleware.__call__` now guards request value extraction with `scope["type"] == "http"`, preventing the crash caused by constructing a Starlette `Request` with a WebSocket scope.
- WebSocket connections still enter `request_context()` for request-scoped dependency isolation, but skip the HTTP-only value extraction step.
- Added a test that connects via WebSocket with `request_values` configured and verifies no crash.

Closes #110

## Test plan
- [x] New test `test_websocket_not_crashed_by_request_values` sets up an app with `RequestValueProvider` and a WebSocket route, connects, and verifies data is received without errors.
- [x] All existing tests continue to pass (309 passed).
- [x] ty check, ruff check, and ruff format all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)