### PR TITLE
Wrap extractor errors with context in RequestScopeMiddleware

### DIFF
--- a/src/uncoiled/fastapi.py
+++ b/src/uncoiled/fastapi.py
@@ -99,9 +99,19 @@ class RequestScopeMiddleware:
                 if self._request_values:
                     request = Request(scope, receive, send)
                     for rv in self._request_values:
+                        try:
+                            value = rv.extractor(request)
+                        except Exception as exc:
+                            msg = (
+                                "Failed to extract request value"
+                                f" for {rv.type_.__name__}"
+                            )
+                            if rv.qualifier:
+                                msg += f" with qualifier '{rv.qualifier}'"
+                            raise ValueError(msg) from exc
                         self._container.provide_request_value(
                             rv.type_,
-                            rv.extractor(request),
+                            value,
                             qualifier=rv.qualifier,
                         )
                 await self._app(scope, receive, send)

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -204,6 +204,73 @@ class TestRequestValueProvider:
         assert resp.json() == {"cid": "req-42"}
 
     @pytest.mark.anyio
+    async def test_extractor_error_includes_context(self) -> None:
+        providers = [
+            RequestValueProvider(
+                _TenantId,
+                lambda r: _TenantId(r.headers["x-nonexistent"]),
+            ),
+        ]
+        c = Container()
+        app = FastAPI()
+        app.add_middleware(
+            RequestScopeMiddleware,  # ty: ignore[invalid-argument-type]
+            container=c,
+            request_values=providers,
+        )
+        configure_container(app, c, request_values=providers)
+
+        @app.get("/")
+        def index(
+            ctr: Annotated[Container, Depends(_get_ctr)],
+        ) -> dict:
+            return {"tenant": ctr.get(_TenantId)}
+
+        with pytest.raises(ValueError, match="_TenantId"):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(
+                    app=app,
+                    raise_app_exceptions=True,
+                ),
+                base_url="http://test",
+            ) as client:
+                await client.get("/")
+
+    @pytest.mark.anyio
+    async def test_extractor_error_includes_qualifier(self) -> None:
+        providers = [
+            RequestValueProvider(
+                str,
+                lambda r: r.headers["x-nonexistent"],
+                qualifier="my_qual",
+            ),
+        ]
+        c = Container()
+        app = FastAPI()
+        app.add_middleware(
+            RequestScopeMiddleware,  # ty: ignore[invalid-argument-type]
+            container=c,
+            request_values=providers,
+        )
+        configure_container(app, c)
+
+        @app.get("/")
+        def index(
+            ctr: Annotated[Container, Depends(_get_ctr)],
+        ) -> dict:
+            return {"val": ctr.get(str, qualifier="my_qual")}
+
+        with pytest.raises(ValueError, match="my_qual"):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(
+                    app=app,
+                    raise_app_exceptions=True,
+                ),
+                base_url="http://test",
+            ) as client:
+                await client.get("/")
+
+    @pytest.mark.anyio
     async def test_concurrent_requests_isolated(self) -> None:
         providers = [
             RequestValueProvider(


### PR DESCRIPTION
## Summary
- Wraps `RequestValueProvider` extractor calls in `RequestScopeMiddleware.__call__` with try/except, re-raising as `ValueError` with a message identifying the type (and qualifier, if present) that failed extraction
- Adds two tests: one verifying the error message includes the type name, another verifying it includes the qualifier

Closes #111

## Test plan
- [x] `test_extractor_error_includes_context` — extractor accessing a missing header raises `ValueError` mentioning `_TenantId`
- [x] `test_extractor_error_includes_qualifier` — qualified extractor error includes the qualifier string in the message
- [x] All 314 tests pass, ruff check/format clean, ty check clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)