### PR TITLE
Key lifecycle hooks by (type, qualifier) instead of type alone

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -59,9 +59,9 @@ class Container:
             Scope.TRANSIENT: TransientScope(),
             Scope.REQUEST: RequestScope(),
         }
-        self._instances: list[object] = []
-        self._destroy_hooks: dict[type, str | None] = {}
-        self._init_hooks: dict[type, str | None] = {}
+        self._instances: list[tuple[object, type, str | None]] = []
+        self._destroy_hooks: dict[tuple[type, str | None], str | None] = {}
+        self._init_hooks: dict[tuple[type, str | None], str | None] = {}
         self._started = False
 
     def register(  # noqa: PLR0913
@@ -89,10 +89,10 @@ class Container:
         self._registrations[key].dependencies = inspect_dependencies(cls)
         if init_method:
             self._check_lifecycle_method(cls, init_method, "init_method")
-            self._init_hooks[cls] = init_method
+            self._init_hooks[(cls, qualifier)] = init_method
         if destroy_method:
             self._check_lifecycle_method(cls, destroy_method, "destroy_method")
-            self._destroy_hooks[cls] = destroy_method
+            self._destroy_hooks[(cls, qualifier)] = destroy_method
 
     def register_instance(
         self,
@@ -113,9 +113,9 @@ class Container:
             qualifier=qualifier,
         )
         self._scopes[Scope.SINGLETON].put(type_, instance, qualifier)
-        self._instances.append(instance)
+        self._instances.append((instance, type_, qualifier))
         if destroy_method:
-            self._destroy_hooks[type_] = destroy_method
+            self._destroy_hooks[(type_, qualifier)] = destroy_method
 
     def register_factory(  # noqa: PLR0913
         self,
@@ -142,9 +142,9 @@ class Container:
         node.dependencies = inspect_dependencies(factory)
         self._registrations[key] = node
         if init_method:
-            self._init_hooks[return_type] = init_method
+            self._init_hooks[(return_type, qualifier)] = init_method
         if destroy_method:
-            self._destroy_hooks[return_type] = destroy_method
+            self._destroy_hooks[(return_type, qualifier)] = destroy_method
 
     def register_request_value(
         self,
@@ -254,9 +254,9 @@ class Container:
     def close(self) -> None:
         """Destroy instances in reverse creation order."""
         errors: list[Exception] = []
-        for instance in reversed(self._instances):
+        for instance, impl, qualifier in reversed(self._instances):
             try:
-                destroy_method = self._destroy_hooks.get(type(instance))
+                destroy_method = self._destroy_hooks.get((impl, qualifier))
                 call_destroy(instance, destroy_method)
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
@@ -271,9 +271,9 @@ class Container:
     async def aclose(self) -> None:
         """Destroy instances in reverse creation order (async)."""
         errors: list[Exception] = []
-        for instance in reversed(self._instances):
+        for instance, impl, qualifier in reversed(self._instances):
             try:
-                destroy_method = self._destroy_hooks.get(type(instance))
+                destroy_method = self._destroy_hooks.get((impl, qualifier))
                 await async_call_destroy(instance, destroy_method)
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
@@ -322,9 +322,10 @@ class Container:
         if scope_manager:
             scope_manager.put(type_, instance, qualifier)
 
-        if node.scope is not Scope.TRANSIENT or node.impl in self._destroy_hooks:
-            self._instances.append(instance)
-        call_init(instance, self._init_hooks.get(node.impl))
+        hook_key = (node.impl, qualifier)
+        if node.scope is not Scope.TRANSIENT or hook_key in self._destroy_hooks:
+            self._instances.append((instance, node.impl, qualifier))
+        call_init(instance, self._init_hooks.get(hook_key))
 
         return instance  # ty: ignore[invalid-return-type]
 
@@ -349,9 +350,10 @@ class Container:
         if scope_manager:
             scope_manager.put(type_, instance, qualifier)
 
-        if node.scope is not Scope.TRANSIENT or node.impl in self._destroy_hooks:
-            self._instances.append(instance)
-        await async_call_init(instance, self._init_hooks.get(node.impl))
+        hook_key = (node.impl, qualifier)
+        if node.scope is not Scope.TRANSIENT or hook_key in self._destroy_hooks:
+            self._instances.append((instance, node.impl, qualifier))
+        await async_call_init(instance, self._init_hooks.get(hook_key))
 
         return instance  # ty: ignore[invalid-return-type]
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -520,6 +520,71 @@ class TestContainerLifecycle:
         c.close()
         assert res.closed
 
+    def test_qualified_init_methods_are_independent(self) -> None:
+        class ServiceA:
+            started = False
+
+            def boot(self) -> None:
+                self.started = True
+
+        class ServiceB:
+            started = False
+
+            def setup(self) -> None:
+                self.started = True
+
+        c = Container()
+        c.register(
+            ServiceA,
+            provides=Repository,
+            qualifier="a",
+            init_method="boot",
+        )
+        c.register(
+            ServiceB,
+            provides=Repository,
+            qualifier="b",
+            init_method="setup",
+        )
+        c.start()
+        a = c.get(Repository, qualifier="a")
+        b = c.get(Repository, qualifier="b")
+        assert a.started  # ty: ignore[unresolved-attribute]
+        assert b.started  # ty: ignore[unresolved-attribute]
+
+    def test_qualified_destroy_methods_are_independent(self) -> None:
+        class ResourceA:
+            closed = False
+
+            def teardown(self) -> None:
+                self.closed = True
+
+        class ResourceB:
+            closed = False
+
+            def cleanup(self) -> None:
+                self.closed = True
+
+        c = Container()
+        c.register(
+            ResourceA,
+            provides=Repository,
+            qualifier="a",
+            destroy_method="teardown",
+        )
+        c.register(
+            ResourceB,
+            provides=Repository,
+            qualifier="b",
+            destroy_method="cleanup",
+        )
+        c.start()
+        a = c.get(Repository, qualifier="a")
+        b = c.get(Repository, qualifier="b")
+        c.close()
+        assert a.closed  # ty: ignore[unresolved-attribute]
+        assert b.closed  # ty: ignore[unresolved-attribute]
+
 
 class TestSingletonQualifierIsolation:
     def test_different_qualifiers_return_different_instances(self) -> None:


### PR DESCRIPTION
## Summary
- Changed `_init_hooks` and `_destroy_hooks` from `dict[type, str | None]` to `dict[tuple[type, str | None], str | None]`, keying by `(type, qualifier)` like `_registrations`
- Changed `_instances` from `list[object]` to `list[tuple[object, type, str | None]]` so `close()`/`aclose()` can look up the correct destroy hook per qualifier
- Updated all read/write sites: `register`, `register_instance`, `register_factory`, `_resolve`, `_aresolve`, `close`, `aclose`
- Added tests proving that same type with different qualifiers can have independent init and destroy methods

Closes #109

## Test plan
- [x] Existing tests pass (310/310)
- [x] New test: qualified init methods are independent (different init methods on same type with different qualifiers)
- [x] New test: qualified destroy methods are independent (different destroy methods on same type with different qualifiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)