### PR TITLE
Reject singleton depending on request-scoped component

### DIFF
--- a/src/uncoiled/_errors.py
+++ b/src/uncoiled/_errors.py
@@ -12,6 +12,7 @@ class FailureKind(enum.Enum):
     MISSING = "missing"
     CIRCULAR = "circular"
     AMBIGUOUS = "ambiguous"
+    SCOPE_MISMATCH = "scope_mismatch"
 
 
 @dataclass(frozen=True)

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -88,6 +88,29 @@ def build_graph(
                 )
                 continue
 
+            dep_node = registrations[dep_key]
+            if node.scope is Scope.SINGLETON and dep_node.scope is Scope.REQUEST:
+                failures.append(
+                    ResolutionFailure(
+                        kind=FailureKind.SCOPE_MISMATCH,
+                        message=(
+                            f"Singleton '{node.impl.__name__}' depends on "
+                            f"request-scoped '{dep_node.impl.__name__}' — "
+                            f"singletons cannot depend on request-scoped "
+                            f"components because they are created at startup "
+                            f"before any request context exists."
+                        ),
+                        suggestion=(
+                            f"Change '{node.impl.__name__}' to request scope, "
+                            f"or remove the dependency on "
+                            f"'{dep_node.impl.__name__}'."
+                        ),
+                        component=node.impl,
+                        parameter=dep.name,
+                    ),
+                )
+                continue
+
             adj[dep_key].add(key)
             in_degree[key] = in_degree.get(key, 0) + 1
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -9,6 +9,7 @@ from uncoiled import (
     DependencyResolutionError,
     FailureKind,
     Qualifier,
+    Scope,
     build_graph,
     validate_graph,
 )
@@ -47,6 +48,25 @@ class NeedsOptThenReq:
     def __init__(self, opt: Repository | None, req: ExtraService) -> None:
         self.opt = opt
         self.req = req
+
+
+class RequestDep:
+    pass
+
+
+class SingletonNeedsRequest:
+    def __init__(self, dep: RequestDep) -> None:
+        self.dep = dep
+
+
+class RequestNeedsRequest:
+    def __init__(self, dep: RequestDep) -> None:
+        self.dep = dep
+
+
+class TransientNeedsRequest:
+    def __init__(self, dep: RequestDep) -> None:
+        self.dep = dep
 
 
 class TestBuildGraph:
@@ -255,6 +275,62 @@ class TestBuildGraph:
         assert len(failures) == 1
         assert failures[0].kind is FailureKind.MISSING
         assert "ExtraService" in failures[0].message
+
+
+class TestScopeMismatch:
+    def test_singleton_depending_on_request_scoped_fails_validation(self) -> None:
+        """A singleton cannot depend on a request-scoped component."""
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=RequestDep,
+                provides=RequestDep,
+                scope=Scope.REQUEST,
+            ),
+            ComponentNode(
+                impl=SingletonNeedsRequest,
+                provides=SingletonNeedsRequest,
+                scope=Scope.SINGLETON,
+            ),
+        )
+        failures = build_graph(registrations)
+        assert len(failures) == 1
+        assert failures[0].kind is FailureKind.SCOPE_MISMATCH
+        assert "SingletonNeedsRequest" in failures[0].message
+        assert "RequestDep" in failures[0].message
+        assert failures[0].component is SingletonNeedsRequest
+        assert failures[0].parameter == "dep"
+
+    def test_request_scoped_depending_on_request_scoped_passes(self) -> None:
+        """A request-scoped component can depend on another request-scoped one."""
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=RequestDep,
+                provides=RequestDep,
+                scope=Scope.REQUEST,
+            ),
+            ComponentNode(
+                impl=RequestNeedsRequest,
+                provides=RequestNeedsRequest,
+                scope=Scope.REQUEST,
+            ),
+        )
+        assert build_graph(registrations) == []
+
+    def test_transient_depending_on_request_scoped_passes(self) -> None:
+        """A transient component can depend on a request-scoped one."""
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=RequestDep,
+                provides=RequestDep,
+                scope=Scope.REQUEST,
+            ),
+            ComponentNode(
+                impl=TransientNeedsRequest,
+                provides=TransientNeedsRequest,
+                scope=Scope.TRANSIENT,
+            ),
+        )
+        assert build_graph(registrations) == []
 
 
 class TestValidateGraph:


### PR DESCRIPTION
## Summary
- Adds a new `FailureKind.SCOPE_MISMATCH` variant for scope validation errors
- During `build_graph()`, detects when a singleton component depends on a request-scoped component and emits a clear `ResolutionFailure` explaining why this is invalid
- Transient and request-scoped components depending on request-scoped components remain valid

## Test plan
- [x] `test_singleton_depending_on_request_scoped_fails_validation` — verifies the failure is reported with correct kind, message, component, and parameter
- [x] `test_request_scoped_depending_on_request_scoped_passes` — confirms request-to-request dependency is allowed
- [x] `test_transient_depending_on_request_scoped_passes` — confirms transient-to-request dependency is allowed
- [x] All 311 tests pass, ruff lint/format clean

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)