### PR TITLE
Remove unused FailureKind.AMBIGUOUS enum value

### DIFF
--- a/src/uncoiled/_errors.py
+++ b/src/uncoiled/_errors.py
@@ -11,7 +11,6 @@ class FailureKind(enum.Enum):
 
     MISSING = "missing"
     CIRCULAR = "circular"
-    AMBIGUOUS = "ambiguous"
 
 
 @dataclass(frozen=True)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -73,9 +73,9 @@ class TestDependencyResolutionError:
 
     def test_failures_accessible(self) -> None:
         failure = ResolutionFailure(
-            kind=FailureKind.AMBIGUOUS,
-            message="Ambiguous.",
-            suggestion="Use a qualifier.",
+            kind=FailureKind.MISSING,
+            message="Missing.",
+            suggestion="Register it.",
             component=int,
             parameter="value",
         )


### PR DESCRIPTION
## Summary
- Removed the `AMBIGUOUS` variant from `FailureKind` since there is no ambiguity detection logic in the codebase
- Updated the test that referenced `FailureKind.AMBIGUOUS` to use `FailureKind.MISSING` instead, preserving test coverage for the `component` and `parameter` optional fields

Closes #116

## Test plan
- [x] All 308 tests pass
- [x] Type checks pass (`ty check`)
- [x] Lint passes (`ruff check`)
- [x] Formatting passes (`ruff format --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)