### PR TITLE
Add context to config coercion errors

### DIFF
--- a/src/uncoiled/_config/_binding.py
+++ b/src/uncoiled/_config/_binding.py
@@ -85,7 +85,13 @@ def bind_config[T](cls: type[T], source: ConfigSource) -> T:
         key = f"{prefix}.{field.name}" if prefix else field.name
         raw = source.get(normalise(key))
         if raw is not None:
-            kwargs[field.name] = _coerce(raw, hints[field.name])
+            try:
+                kwargs[field.name] = _coerce(raw, hints[field.name])
+            except (ValueError, TypeError) as exc:
+                target = hints[field.name]
+                type_name = getattr(target, "__name__", str(target))
+                msg = f"Cannot coerce config key '{key}' value {raw!r} to {type_name}"
+                raise ValueError(msg) from exc
         elif (
             field.default is not dataclasses.MISSING
             or field.default_factory is not dataclasses.MISSING

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -92,3 +92,19 @@ class TestConfigProperties:
         source = DictSource({})
         with pytest.raises(ValueError, match="Missing required"):
             bind_config(SvcConfig, source)
+
+    def test_bind_config_invalid_int_shows_key(self) -> None:
+        source = DictSource({"db.host": "localhost", "db.port": "not_a_number"})
+        with pytest.raises(
+            ValueError,
+            match=r"Cannot coerce config key 'db\.port'.*to int",
+        ):
+            bind_config(DbConfig, source)
+
+    def test_bind_config_invalid_bool_shows_key(self) -> None:
+        source = DictSource({"app.name": "test", "app.debug": "not_a_bool"})
+        with pytest.raises(
+            ValueError,
+            match=r"Cannot coerce config key 'app\.debug'.*to bool",
+        ):
+            bind_config(AppConfig, source)


### PR DESCRIPTION
## Summary
- Wraps the `_coerce()` call in `bind_config()` with a try/except that catches `ValueError`/`TypeError` and re-raises with context about which config key failed and what value/type was involved
- Adds two tests verifying the error message includes the key name for invalid int and bool coercions

Closes #114

## Test plan
- [x] `test_bind_config_invalid_int_shows_key`: sets `db.port` to `"not_a_number"`, asserts error mentions `db.port` and `int`
- [x] `test_bind_config_invalid_bool_shows_key`: sets `app.debug` to `"not_a_bool"`, asserts error mentions `app.debug` and `bool`
- [x] Existing `test_bool_coercion_invalid_raises` still passes (message still matches `"Cannot coerce"`)
- [x] All 310 tests pass, type check / lint / format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)