### PR TITLE
Validate provides type in register()

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -78,6 +78,7 @@ class Container:
         """Register a class as a component."""
         self._check_scope(scope)
         provides = provides or cls
+        self._check_provides(cls, provides)
         key = (provides, qualifier)
         self._check_duplicate(key, replace=replace)
         self._registrations[key] = ComponentNode(
@@ -489,6 +490,20 @@ class Container:
                 msg += f" with qualifier '{qualifier}'"
             msg += "; pass replace=True to override"
             raise ValueError(msg)
+
+    @staticmethod
+    def _check_provides(impl: type, provides: type) -> None:
+        """Raise if *impl* is not a subclass of *provides*."""
+        if provides is impl:
+            return
+        try:
+            is_sub = issubclass(impl, provides)
+        except TypeError:
+            # issubclass fails on Protocol types and similar — skip check.
+            return
+        if not is_sub:
+            msg = f"{impl.__name__} is not a subclass of {provides.__name__}"
+            raise TypeError(msg)
 
     def _check_scope(self, scope: Scope) -> None:
         """Raise if the scope has no registered manager."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -102,6 +102,36 @@ class TestContainerRegistration:
         with pytest.raises(ValueError, match=r"destroy_method.*nonexistent"):
             c.register(Repository, destroy_method="nonexistent")
 
+    def test_register_incompatible_provides_raises(self) -> None:
+        c = Container()
+        with pytest.raises(TypeError, match="str is not a subclass of int"):
+            c.register(str, provides=int)
+
+    def test_register_compatible_provides_passes(self) -> None:
+        class Base:
+            pass
+
+        class Sub(Base):
+            pass
+
+        c = Container()
+        c.register(Sub, provides=Base)
+        assert isinstance(c.get(Base), Sub)
+
+    def test_register_provides_protocol_skips_check(self) -> None:
+        from typing import Protocol, runtime_checkable  # noqa: PLC0415
+
+        @runtime_checkable
+        class Greeter(Protocol):
+            def greet(self) -> str: ...
+
+        class EnglishGreeter:
+            def greet(self) -> str:
+                return "hello"
+
+        c = Container()
+        c.register(EnglishGreeter, provides=Greeter)  # should not raise
+
 
 class TestContainerResolution:
     def test_singleton_scope(self) -> None:


### PR DESCRIPTION
## Summary
- Added `_check_provides()` validation to `Container.register()` that raises `TypeError` when `cls` is not a subclass of `provides`
- Uses `try/except` around `issubclass` to gracefully skip validation for Protocol types (where `issubclass` raises `TypeError`)
- The scan path (`_register_from_module`) already delegates to `register()`, so it gets the validation for free

## Test plan
- [x] `test_register_incompatible_provides_raises` -- `register(str, provides=int)` raises `TypeError`
- [x] `test_register_compatible_provides_passes` -- `register(Sub, provides=Base)` works fine
- [x] `test_register_provides_protocol_skips_check` -- Protocol as `provides` does not raise
- [x] All 311 existing tests still pass

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)