### PR TITLE
Remove unused FailureKind.AMBIGUOUS

### DIFF
--- a/src/uncoiled/_errors.py
+++ b/src/uncoiled/_errors.py
@@ -11,7 +11,6 @@ class FailureKind(enum.Enum):
 
     MISSING = "missing"
     CIRCULAR = "circular"
-    AMBIGUOUS = "ambiguous"
     SCOPE_MISMATCH = "scope_mismatch"
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -73,9 +73,9 @@ class TestDependencyResolutionError:
 
     def test_failures_accessible(self) -> None:
         failure = ResolutionFailure(
-            kind=FailureKind.AMBIGUOUS,
-            message="Ambiguous.",
-            suggestion="Use a qualifier.",
+            kind=FailureKind.MISSING,
+            message="Missing.",
+            suggestion="Register a component.",
             component=int,
             parameter="value",
         )


### PR DESCRIPTION
## Summary

- Remove `FailureKind.AMBIGUOUS` enum value — it was defined but never raised by any validation logic
- Update test to use `FailureKind.MISSING` instead

Closes #116

## Test plan

- [x] All 314 tests pass
- [x] ty/ruff/format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)