### PR TITLE
Add dependency graph visualisation

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -209,6 +209,19 @@ class Container:
         """Validate the dependency graph eagerly."""
         validate_graph(self._registrations)
 
+    def visualise(self) -> str:
+        """Render the dependency graph as a Mermaid flowchart.
+
+        Returns a string that can be embedded in Markdown::
+
+            ```mermaid
+            print(container.visualise())
+            ```
+        """
+        from ._visualise import render_mermaid  # noqa: PLC0415
+
+        return render_mermaid(self._registrations)
+
     def start(self) -> None:
         """Validate the graph and instantiate all singletons."""
         self.validate()

--- a/src/uncoiled/_visualise.py
+++ b/src/uncoiled/_visualise.py
@@ -1,0 +1,87 @@
+"""Dependency graph visualisation — renders registrations as Mermaid diagrams."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._inspection import inspect_dependencies
+from ._types import Scope
+
+if TYPE_CHECKING:
+    from ._graph import ComponentNode
+
+
+def _node_id(type_: type, qualifier: str | None) -> str:
+    """Create a stable Mermaid node ID from a type and qualifier."""
+    name = type_.__name__
+    if qualifier:
+        return f"{name}_{qualifier}"
+    return name
+
+
+def _node_label(node: ComponentNode) -> str:
+    """Create a display label for a node, showing scope and qualifier."""
+    name = node.impl.__name__
+    parts: list[str] = []
+    if node.provides is not node.impl:
+        parts.append(f"as {node.provides.__name__}")
+    if node.qualifier:
+        parts.append(f"qualifier={node.qualifier}")
+    if node.scope is not Scope.SINGLETON:
+        parts.append(node.scope.value)
+    if parts:
+        return f"{name}\\n({', '.join(parts)})"
+    return name
+
+
+def _scope_class(scope: Scope) -> str:
+    """Map scope to a Mermaid CSS class name."""
+    return f"scope_{scope.value}"
+
+
+def render_mermaid(
+    registrations: dict[tuple[type, str | None], ComponentNode],
+) -> str:
+    """Render the dependency graph as a Mermaid flowchart.
+
+    Returns a string suitable for embedding in Markdown::
+
+        ```mermaid
+        container.visualise()
+        ```
+    """
+    lines: list[str] = ["graph TD"]
+
+    # Define nodes
+    for (type_, qualifier), node in registrations.items():
+        nid = _node_id(type_, qualifier)
+        label = _node_label(node)
+        lines.append(f"    {nid}[{label}]:::{_scope_class(node.scope)}")
+
+    # Define edges
+    for (type_, qualifier), node in registrations.items():
+        target_id = _node_id(type_, qualifier)
+        factory = node.factory if node.factory is not None else node.impl
+        deps = inspect_dependencies(factory)
+        for dep in deps:
+            if dep.env_var is not None:
+                env_id = f"env_{dep.env_var}"
+                lines.append(f"    {env_id}[/{dep.env_var}/]:::env_var")
+                style = "-.->" if dep.has_default else "-->"
+                lines.append(f"    {env_id} {style} {target_id}")
+                continue
+
+            dep_key = (dep.required_type, dep.qualifier)
+            if dep_key in registrations:
+                dep_id = _node_id(dep.required_type, dep.qualifier)
+                style = "-.->" if dep.optional or dep.has_default else "-->"
+                lines.append(f"    {dep_id} {style} {target_id}")
+
+    # Style definitions
+    lines.append("")
+    lines.append(f"    classDef {_scope_class(Scope.SINGLETON)} fill:#4a9,stroke:#333")
+    lines.append(f"    classDef {_scope_class(Scope.TRANSIENT)} fill:#f96,stroke:#333")
+    lines.append(f"    classDef {_scope_class(Scope.REQUEST)} fill:#69f,stroke:#333")
+    lines.append("    classDef env_var fill:#ff9,stroke:#333")
+
+    return "\n".join(lines)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1180,3 +1180,64 @@ class TestGetAllQualifierFiltering:
         first = await c._aresolve(Repository)  # noqa: SLF001
         second = await c._aresolve(Repository)  # noqa: SLF001
         assert first is second
+
+
+class TestVisualise:
+    def test_empty_container(self) -> None:
+        c = Container()
+        result = c.visualise()
+        assert result.startswith("graph TD")
+
+    def test_single_component(self) -> None:
+        c = Container()
+        c.register(Repository)
+        result = c.visualise()
+        assert "Repository" in result
+
+    def test_dependency_edge(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.register(UserService)
+        result = c.visualise()
+        assert "Repository" in result
+        assert "UserService" in result
+        assert "-->" in result
+
+    def test_scope_shown_for_non_singleton(self) -> None:
+        c = Container()
+        c.register(Repository, scope=Scope.TRANSIENT)
+        result = c.visualise()
+        assert "transient" in result
+
+    def test_qualifier_shown(self) -> None:
+        class RepoA(Repository):
+            pass
+
+        c = Container()
+        c.register(RepoA, provides=Repository, qualifier="primary")
+        result = c.visualise()
+        assert "primary" in result
+
+    def test_envvar_shown(self) -> None:
+        class Service:
+            def __init__(
+                self,
+                url: Annotated[str, EnvVar("DB_URL")] = ":memory:",
+            ) -> None:
+                self.url = url
+
+        c = Container()
+        c.register(Service)
+        result = c.visualise()
+        assert "DB_URL" in result
+
+    def test_optional_uses_dashed_edge(self) -> None:
+        class OptService:
+            def __init__(self, repo: Repository | None = None) -> None:
+                self.repo = repo
+
+        c = Container()
+        c.register(Repository)
+        c.register(OptService)
+        result = c.visualise()
+        assert "-.->" in result


### PR DESCRIPTION
## Summary

- New `Container.visualise()` method returns a Mermaid flowchart string
- Shows components with scope colour-coding (green=singleton, orange=transient, blue=request)
- Solid edges for required dependencies, dashed for optional/defaulted
- EnvVar injections shown as parallelogram nodes
- Qualifiers and `provides` aliases shown in node labels
- Lazy import of `_visualise` module to avoid overhead when not used

Closes #108

## Example output

```mermaid
graph TD
    Repository[Repository]:::scope_singleton
    UserService[UserService]:::scope_singleton
    Repository --> UserService

    classDef scope_singleton fill:#4a9,stroke:#333
```

## Test plan

- [x] 7 new tests covering empty container, single component, edges, scopes, qualifiers, EnvVar, optional deps
- [x] All 328 tests pass
- [x] ty/ruff/format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)