### PR TITLE
Test inspect_dependencies with deferred annotations

### DIFF
--- a/tests/_future_annotations_helpers.py
+++ b/tests/_future_annotations_helpers.py
@@ -1,0 +1,43 @@
+"""Helper module using ``from __future__ import annotations`` for testing.
+
+All type annotations in this module are stringified at runtime due to
+PEP 563 deferred evaluation. This exercises inspect.get_annotations(eval_str=True).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class Repository:
+    pass
+
+
+class UserService:
+    def __init__(self, repo: Repository) -> None:
+        self.repo = repo
+
+
+class OptionalService:
+    def __init__(self, repo: Repository | None = None) -> None:
+        self.repo = repo
+
+
+class ForwardRefService:
+    def __init__(self, late: LateDefinedClass) -> None:
+        self.late = late
+
+
+class LateDefinedClass:
+    pass
+
+
+@dataclass
+class ParentConfig:
+    host: str = "localhost"
+    port: int = 5432
+
+
+@dataclass
+class ChildConfig(ParentConfig):
+    name: str = "mydb"

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -2,6 +2,14 @@ from typing import Annotated, Optional, Union
 
 import pytest
 
+from tests._future_annotations_helpers import (
+    ChildConfig,
+    ForwardRefService,
+    LateDefinedClass,
+    OptionalService,
+)
+from tests._future_annotations_helpers import Repository as FutureRepo
+from tests._future_annotations_helpers import UserService as FutureService
 from uncoiled import DependencySpec, Qualifier, inspect_dependencies
 
 
@@ -277,6 +285,31 @@ class TestInspectDependencies:
         assert len(specs) == 1
         assert specs[0].qualifier == "pg"
         assert specs[0].required_type is Repository
+
+    def test_future_annotations_resolves_types(self) -> None:
+        """Classes using ``from __future__ import annotations`` should work."""
+        specs = inspect_dependencies(FutureService)
+        assert len(specs) == 1
+        assert specs[0].name == "repo"
+        assert specs[0].required_type is FutureRepo
+
+    def test_future_annotations_optional(self) -> None:
+        specs = inspect_dependencies(OptionalService)
+        assert len(specs) == 1
+        assert specs[0].required_type is FutureRepo
+        assert specs[0].optional is True
+
+    def test_future_annotations_forward_ref(self) -> None:
+        specs = inspect_dependencies(ForwardRefService)
+        assert len(specs) == 1
+        assert specs[0].required_type is LateDefinedClass
+
+    def test_future_annotations_dataclass_inheritance(self) -> None:
+        specs = inspect_dependencies(ChildConfig)
+        field_names = {s.name for s in specs}
+        assert "host" in field_names
+        assert "port" in field_names
+        assert "name" in field_names
 
     def test_function_inspection(self) -> None:
         def factory(repo: Repository, name: str = "x") -> UserService:


### PR DESCRIPTION
## Summary

- New helper module `tests/_future_annotations_helpers.py` using `from __future__ import annotations`
- 4 tests verifying `inspect_dependencies` handles: basic resolution, optional unions, forward references, dataclass inheritance
- All pass — `inspect.get_annotations(eval_str=True)` handles stringified annotations correctly

Closes #130

## Test plan

- [x] All 340 tests pass
- [x] ruff/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)