### PR TITLE
Auto-inject module-named Logger instances

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import inspect
+import logging
 import os
 import pkgutil
 from typing import TYPE_CHECKING, Self
@@ -368,7 +369,7 @@ class Container:
 
         kwargs: dict[str, object] = {}
         for dep in node.dependencies:
-            self._resolve_dependency(dep, kwargs)
+            self._resolve_dependency(dep, kwargs, node=node)
 
         if node.factory is not None:
             result = node.factory(**kwargs)  # ty: ignore[call-non-callable]
@@ -397,7 +398,7 @@ class Container:
 
         kwargs: dict[str, object] = {}
         for dep in node.dependencies:
-            self._resolve_dependency(dep, kwargs)
+            self._resolve_dependency(dep, kwargs, node=node)
 
         if node.factory is not None:
             result = node.factory(**kwargs)  # ty: ignore[call-non-callable]
@@ -417,6 +418,8 @@ class Container:
         self,
         dep: DependencySpec,
         kwargs: dict[str, object],
+        *,
+        node: ComponentNode,
     ) -> None:
         """Resolve a single dependency into kwargs."""
         if dep.env_var is not None:
@@ -429,6 +432,8 @@ class Container:
                     " and no default was provided"
                 )
                 raise LookupError(msg)
+        elif dep.required_type is logging.Logger:
+            kwargs[dep.name] = logging.getLogger(node.impl.__module__)
         elif dep.is_list:
             kwargs[dep.name] = self.get_all(dep.required_type, dep.qualifier)
         elif dep.optional or dep.has_default:

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 
@@ -52,7 +53,11 @@ def build_graph(
         for dep in node.dependencies:
             dep_key = _type_key(dep.required_type, dep.qualifier)
 
-            if dep.is_list or dep.env_var is not None:
+            if (
+                dep.is_list
+                or dep.env_var is not None
+                or dep.required_type is logging.Logger
+            ):
                 continue
 
             if dep_key not in registrations:

--- a/src/uncoiled/_visualise.py
+++ b/src/uncoiled/_visualise.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from ._inspection import inspect_dependencies
@@ -69,6 +70,11 @@ def render_mermaid(
                 lines.append(f"    {env_id}[/{dep.env_var}/]:::env_var")
                 style = "-.->" if dep.has_default else "-->"
                 lines.append(f"    {env_id} {style} {target_id}")
+                continue
+
+            if dep.required_type is logging.Logger:
+                lines.append("    Logger[/Logger/]:::env_var")
+                lines.append(f"    Logger -.-> {target_id}")
                 continue
 
             dep_key = (dep.required_type, dep.qualifier)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,3 +1,4 @@
+import logging
 import types
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -393,6 +394,54 @@ class TestEnvVar:
                 db_url: Annotated[str, EnvVar("DB_URL")] = ":memory:",
             ) -> None:
                 self.db_url = db_url
+
+        c = Container()
+        c.register(Service)
+        c.validate()  # should not raise
+
+
+class TestLoggerInjection:
+    def test_logger_auto_injected(self) -> None:
+        class Service:
+            def __init__(self, logger: logging.Logger) -> None:
+                self.logger = logger
+
+        c = Container()
+        c.register(Service)
+        svc = c.get(Service)
+        assert isinstance(svc.logger, logging.Logger)
+
+    def test_logger_named_after_module(self) -> None:
+        class Service:
+            def __init__(self, logger: logging.Logger) -> None:
+                self.logger = logger
+
+        c = Container()
+        c.register(Service)
+        svc = c.get(Service)
+        assert svc.logger.name == Service.__module__
+
+    def test_logger_with_other_deps(self) -> None:
+        class Service:
+            def __init__(
+                self,
+                repo: Repository,
+                logger: logging.Logger,
+            ) -> None:
+                self.repo = repo
+                self.logger = logger
+
+        c = Container()
+        c.register(Repository)
+        c.register(Service)
+        svc = c.get(Service)
+        assert isinstance(svc.repo, Repository)
+        assert isinstance(svc.logger, logging.Logger)
+
+    def test_logger_passes_validation(self) -> None:
+        class Service:
+            def __init__(self, logger: logging.Logger) -> None:
+                self.logger = logger
 
         c = Container()
         c.register(Service)


### PR DESCRIPTION
## Summary

- `logging.Logger` dependencies are automatically provided without registration
- Logger is named after the requesting component's module (`node.impl.__module__`)
- Graph validation skips Logger deps (auto-provided, like EnvVar)
- Visualisation shows Logger as a special node

## Example

```python
import logging

class UserService:
    def __init__(self, repo: UserRepository, logger: logging.Logger) -> None:
        self.repo = repo
        self.logger = logger  # auto-named "myapp.services"
```

No `container.register()` call needed for the logger.

Closes #135

## Test plan

- [x] `test_logger_auto_injected` — Logger instance provided
- [x] `test_logger_named_after_module` — name matches `__module__`
- [x] `test_logger_with_other_deps` — works alongside regular deps
- [x] `test_logger_passes_validation` — graph validation succeeds
- [x] All 347 tests pass, ruff/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)