### PR TITLE
Allow explicit Logger registration to override auto-injection

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -432,7 +432,10 @@ class Container:
                     " and no default was provided"
                 )
                 raise LookupError(msg)
-        elif dep.required_type is logging.Logger:
+        elif (
+            dep.required_type is logging.Logger
+            and (dep.required_type, dep.qualifier) not in self._registrations
+        ):
             kwargs[dep.name] = logging.getLogger(node.impl.__module__)
         elif dep.is_list:
             kwargs[dep.name] = self.get_all(dep.required_type, dep.qualifier)

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -56,7 +56,9 @@ def build_graph(
             if (
                 dep.is_list
                 or dep.env_var is not None
-                or dep.required_type is logging.Logger
+                or (
+                    dep.required_type is logging.Logger and dep_key not in registrations
+                )
             ):
                 continue
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -447,6 +447,19 @@ class TestLoggerInjection:
         c.register(Service)
         c.validate()  # should not raise
 
+    def test_explicit_registration_overrides_auto_logger(self) -> None:
+        class Service:
+            def __init__(self, logger: logging.Logger) -> None:
+                self.logger = logger
+
+        custom = logging.getLogger("custom")
+        c = Container()
+        c.register_instance(custom, type_=logging.Logger)
+        c.register(Service)
+        svc = c.get(Service)
+        assert svc.logger is custom
+        assert svc.logger.name == "custom"
+
 
 class TestContainerValidation:
     def test_validate_raises_on_missing(self) -> None:


### PR DESCRIPTION
## Summary

- Auto-injected Logger now defers to explicit registrations
- Both `_resolve_dependency` and `build_graph` check `self._registrations` / `registrations` before falling back to auto-injection
- New test: `test_explicit_registration_overrides_auto_logger`

## Test plan

- [x] New test verifies explicit `register_instance(custom_logger)` takes precedence
- [x] All 348 tests pass, ruff/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)