### PR TITLE
Close mutation testing gap in .env quote parsing

### DIFF
--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -108,6 +108,15 @@ class TestDotEnvSource:
         source = DotEnvSource(str(p))
         assert source.get("mix") == "\"value'"
 
+    def test_mismatched_quotes_reversed_not_stripped(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        p = tmp_path / ".env"
+        p.write_text("MIX='value\"\n")
+        source = DotEnvSource(str(p))
+        assert source.get("mix") == "'value\""
+
     def test_unquoted_value_with_quotes_inside(self, tmp_path: pathlib.Path) -> None:
         p = tmp_path / ".env"
         p.write_text("MSG=it's fine\n")


### PR DESCRIPTION
## Summary

Mutation testing (cosmic-ray, 1615 mutants) found 1 true positive: the quote-matching check `value[0] == value[-1]` in DotEnvSource could be mutated to `>=` without any test catching it.

The existing `test_mismatched_quotes_not_stripped` used `"value'` (ordinal 34 vs 39, `>=` is False) but not the reverse `'value"` (ordinal 39 vs 34, `>=` would be True, incorrectly stripping quotes).

## Mutation testing results

- 1615 mutants total, 1597 killed (98.9%)
- 18 survivors: 15 type-annotation mutations (false positives), 2 equivalent mutants, **1 true positive** (this fix)

## Test plan

- [x] New test: `test_mismatched_quotes_reversed_not_stripped`
- [x] All 349 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)