### PR TITLE
Add @factory decorator for functions and classmethods

### DIFF
--- a/src/example/infra.py
+++ b/src/example/infra.py
@@ -6,24 +6,26 @@ import sqlite3
 
 from example.config import DbConfig  # noqa: TC001 — injected at runtime
 from example.domain import User, UserRepository
-from uncoiled import Scope, component
+from uncoiled import factory
 
 
-@component(provides=UserRepository, scope=Scope.SINGLETON)
 class SqliteUserRepository:
-    """SQLite-backed implementation of ``UserRepository``.
+    """SQLite-backed implementation of ``UserRepository``."""
 
-    Receives ``DbConfig`` via constructor injection — the container
-    auto-wires it from the registered config instance.
-    """
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
 
-    def __init__(self, config: DbConfig) -> None:
-        self._conn = sqlite3.connect(config.url, check_same_thread=False)
-        self._conn.execute(
+    @factory(provides=UserRepository)
+    @classmethod
+    def create(cls, config: DbConfig) -> SqliteUserRepository:
+        """Build from config — connects to SQLite and ensures schema."""
+        conn = sqlite3.connect(config.url, check_same_thread=False)
+        conn.execute(
             "CREATE TABLE IF NOT EXISTS users "
             "(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, email TEXT)",
         )
-        self._conn.commit()
+        conn.commit()
+        return cls(conn)
 
     def find_by_id(self, user_id: int) -> User | None:
         """Look up a user by ID."""

--- a/src/uncoiled/__init__.py
+++ b/src/uncoiled/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib import metadata
 
-from ._component import ComponentMetadata, component
+from ._component import ComponentMetadata, component, factory
 from ._config._binding import bind_config, config_properties
 from ._config._profiles import get_active_profiles
 from ._config._relaxed import normalise
@@ -59,6 +59,7 @@ __all__ = [
     "call_init",
     "component",
     "config_properties",
+    "factory",
     "get_active_profiles",
     "inspect_dependencies",
     "normalise",

--- a/src/uncoiled/_component.py
+++ b/src/uncoiled/_component.py
@@ -1,20 +1,30 @@
-"""``@component`` decorator for marking DI-managed classes."""
+"""``@component`` and ``@factory`` decorators for marking DI-managed types."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import overload
+from typing import TYPE_CHECKING, overload
 
 from ._types import Scope
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    type _FactoryTarget = Callable[..., object] | classmethod
 
 
 @dataclass(frozen=True)
 class ComponentMetadata:
-    """Metadata attached to a class by the ``@component`` decorator."""
+    """Metadata attached to a class or factory by a DI decorator."""
 
     scope: Scope = Scope.SINGLETON
     qualifier: str | None = None
     provides: type | None = None
+
+
+# ---------------------------------------------------------------------------
+# @component — marks a class for constructor injection
+# ---------------------------------------------------------------------------
 
 
 @overload
@@ -72,3 +82,80 @@ class _ComponentDecorator:
     def __call__(self, cls: type) -> type:
         cls.__uncoiled__ = self._meta  # ty: ignore[unresolved-attribute]
         return cls
+
+
+# ---------------------------------------------------------------------------
+# @factory — marks a function or classmethod as a DI-managed factory
+# ---------------------------------------------------------------------------
+
+
+def _apply_factory_metadata(
+    target: _FactoryTarget,
+    meta: ComponentMetadata,
+) -> _FactoryTarget:
+    """Attach metadata to a factory function or classmethod descriptor."""
+    if isinstance(target, classmethod):
+        target.__func__.__uncoiled__ = meta  # ty: ignore[unresolved-attribute]
+    else:
+        target.__uncoiled__ = meta  # ty: ignore[invalid-assignment]
+    return target
+
+
+@overload
+def factory(target: _FactoryTarget, /) -> _FactoryTarget: ...
+
+
+@overload
+def factory(
+    *,
+    scope: Scope = ...,
+    qualifier: str | None = ...,
+    provides: type | None = ...,
+) -> _FactoryDecorator: ...
+
+
+def factory(
+    target: _FactoryTarget | None = None,
+    /,
+    *,
+    scope: Scope = Scope.SINGLETON,
+    qualifier: str | None = None,
+    provides: type | None = None,
+) -> _FactoryTarget | _FactoryDecorator:
+    """Mark a function or classmethod as a DI-managed factory.
+
+    Can be used with or without arguments::
+
+        @factory
+        def create_client(config: Config) -> HttpClient: ...
+
+        @factory(scope=Scope.TRANSIENT, qualifier="special")
+        def create_service() -> Service: ...
+
+        @factory
+        @classmethod
+        def from_config(cls, source: ConfigSource) -> Repository: ...
+
+    The return type annotation determines the provided type.  Use
+    ``provides=`` to override when the interface differs from the
+    concrete return type.
+
+    Attaches ``ComponentMetadata`` as a ``__uncoiled__`` attribute.
+    Does not modify callable behaviour.
+    """
+    meta = ComponentMetadata(scope=scope, qualifier=qualifier, provides=provides)
+
+    if target is not None:
+        return _apply_factory_metadata(target, meta)
+
+    return _FactoryDecorator(meta)
+
+
+class _FactoryDecorator:
+    """Callable returned by ``@factory(...)`` with arguments."""
+
+    def __init__(self, meta: ComponentMetadata) -> None:
+        self._meta = meta
+
+    def __call__(self, target: _FactoryTarget) -> _FactoryTarget:
+        return _apply_factory_metadata(target, self._meta)

--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -18,7 +18,7 @@ from ._scope import RequestScope, SingletonScope, TransientScope
 from ._types import Scope
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from types import ModuleType
 
     from ._component import ComponentMetadata
@@ -26,6 +26,20 @@ if TYPE_CHECKING:
 
 
 _REQUEST_VALUE_SENTINEL = object()
+
+
+def _infer_return_type(fn: Callable[..., object]) -> type:
+    """Infer the provided type from a factory's return annotation."""
+    hints = inspect.get_annotations(fn, eval_str=True)
+    ret = hints.get("return")
+    if ret is None or not isinstance(ret, type):
+        name = getattr(fn, "__name__", repr(fn))
+        msg = (
+            f"@factory-decorated callable '{name}' must have a return type "
+            f"annotation or explicit provides="
+        )
+        raise TypeError(msg)
+    return ret
 
 
 class Container:
@@ -170,14 +184,14 @@ class Container:
         self._scopes[Scope.REQUEST].put(type_, value, qualifier)
 
     def scan(self, *modules: str | ModuleType) -> None:
-        """Scan modules for ``@component``-decorated classes and register them."""
+        """Scan modules for ``@component`` classes and ``@factory`` callables."""
         for module in modules:
             mod = importlib.import_module(module) if isinstance(module, str) else module
             self._scan_module(mod)
 
     def _scan_module(self, mod: ModuleType) -> None:
         """Scan a single module and its submodules for components."""
-        seen: set[type] = set()
+        seen: set[object] = set()
         self._register_from_module(mod, seen)
 
         if hasattr(mod, "__path__"):
@@ -191,9 +205,9 @@ class Container:
     def _register_from_module(
         self,
         mod: ModuleType,
-        seen: set[type],
+        seen: set[object],
     ) -> None:
-        """Register all ``@component``-decorated classes found in a module."""
+        """Register ``@component`` classes and ``@factory`` callables."""
         for _name, obj in inspect.getmembers(mod, inspect.isclass):
             if obj in seen:
                 continue
@@ -205,6 +219,50 @@ class Container:
                     scope=meta.scope,
                     qualifier=meta.qualifier,
                     provides=meta.provides,
+                )
+            self._register_factory_classmethods(obj, seen)
+
+        for _name, obj in inspect.getmembers(mod, inspect.isfunction):
+            if obj in seen:
+                continue
+            meta = getattr(obj, "__uncoiled__", None)
+            if meta is not None:
+                seen.add(obj)
+                return_type = meta.provides or _infer_return_type(obj)
+                self.register_factory(
+                    obj,
+                    return_type=return_type,
+                    scope=meta.scope,
+                    qualifier=meta.qualifier,
+                )
+
+    def _register_factory_classmethods(
+        self,
+        cls: type,
+        seen: set[object],
+    ) -> None:
+        """Discover and register ``@factory``-decorated classmethods on *cls*."""
+        for attr_name in cls.__dict__:
+            attr = cls.__dict__[attr_name]
+            if not isinstance(attr, classmethod):
+                continue
+            fn = attr.__func__
+            if fn in seen:
+                continue
+            meta: ComponentMetadata | None = getattr(
+                fn,
+                "__uncoiled__",
+                None,
+            )
+            if meta is not None:
+                seen.add(fn)
+                bound = getattr(cls, attr_name)
+                return_type = meta.provides or _infer_return_type(fn)
+                self.register_factory(
+                    bound,
+                    return_type=return_type,
+                    scope=meta.scope,
+                    qualifier=meta.qualifier,
                 )
 
     def validate(self) -> None:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,8 +1,8 @@
-from uncoiled import ComponentMetadata, Scope, component
+from uncoiled import ComponentMetadata, Scope, component, factory
 
 
-def _get_metadata(cls: type) -> ComponentMetadata:
-    return cls.__uncoiled__  # ty: ignore[unresolved-attribute]
+def _get_metadata(target: object) -> ComponentMetadata:
+    return target.__uncoiled__  # ty: ignore[unresolved-attribute]
 
 
 class TestComponentDecorator:
@@ -80,3 +80,103 @@ class TestComponentDecorator:
         else:
             msg = "Expected frozen dataclass to reject mutation"
             raise AssertionError(msg)
+
+
+class _Dummy:
+    pass
+
+
+class TestFactoryOnFunction:
+    def test_bare_decorator_attaches_metadata(self) -> None:
+        @factory
+        def create() -> _Dummy:
+            return _Dummy()
+
+        assert hasattr(create, "__uncoiled__")
+        assert _get_metadata(create) == ComponentMetadata()
+
+    def test_decorator_with_scope(self) -> None:
+        @factory(scope=Scope.TRANSIENT)
+        def create() -> _Dummy:
+            return _Dummy()
+
+        assert _get_metadata(create).scope is Scope.TRANSIENT
+
+    def test_decorator_with_qualifier(self) -> None:
+        @factory(qualifier="special")
+        def create() -> _Dummy:
+            return _Dummy()
+
+        assert _get_metadata(create).qualifier == "special"
+
+    def test_decorator_with_provides(self) -> None:
+        @factory(provides=_Dummy)
+        def create_impl() -> _Dummy:
+            return _Dummy()
+
+        assert _get_metadata(create_impl).provides is _Dummy
+
+    def test_does_not_modify_function(self) -> None:
+        @factory
+        def create() -> _Dummy:
+            return _Dummy()
+
+        assert isinstance(create(), _Dummy)  # ty: ignore[call-non-callable]
+
+    def test_decorator_with_all_options(self) -> None:
+        @factory(scope=Scope.TRANSIENT, qualifier="special", provides=_Dummy)
+        def create() -> _Dummy:
+            return _Dummy()
+
+        expected = ComponentMetadata(
+            scope=Scope.TRANSIENT,
+            qualifier="special",
+            provides=_Dummy,
+        )
+        assert _get_metadata(create) == expected
+
+
+class TestFactoryOnClassmethod:
+    def test_factory_then_classmethod(self) -> None:
+        class MyFactory:
+            @factory
+            @classmethod
+            def create(cls) -> _Dummy:
+                return _Dummy()
+
+        desc = MyFactory.__dict__["create"]
+        assert isinstance(desc, classmethod)
+        assert hasattr(desc.__func__, "__uncoiled__")
+        assert _get_metadata(desc.__func__) == ComponentMetadata()
+
+    def test_classmethod_then_factory(self) -> None:
+        class MyFactory:
+            @classmethod
+            @factory
+            def create(cls) -> _Dummy:
+                return _Dummy()
+
+        desc = MyFactory.__dict__["create"]
+        assert isinstance(desc, classmethod)
+        assert hasattr(desc.__func__, "__uncoiled__")
+        assert _get_metadata(desc.__func__) == ComponentMetadata()
+
+    def test_with_arguments(self) -> None:
+        class MyFactory:
+            @factory(scope=Scope.TRANSIENT, qualifier="x")
+            @classmethod
+            def create(cls) -> _Dummy:
+                return _Dummy()
+
+        meta = _get_metadata(MyFactory.__dict__["create"].__func__)
+        expected = ComponentMetadata(scope=Scope.TRANSIENT, qualifier="x")
+        assert meta == expected
+
+    def test_classmethod_still_callable(self) -> None:
+        class MyFactory:
+            @factory
+            @classmethod
+            def create(cls) -> _Dummy:
+                return _Dummy()
+
+        assert isinstance(MyFactory.create(), _Dummy)  # ty: ignore[call-non-callable]

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -13,6 +13,7 @@ from uncoiled import (
     Qualifier,
     Scope,
     component,
+    factory,
 )
 
 
@@ -1397,3 +1398,185 @@ class TestVisualise:
         from mermaid import Mermaid  # noqa: PLC0415
 
         Mermaid(result)  # raises MermaidError on invalid syntax
+
+
+class TestScanFactoryFunctions:
+    def test_scan_finds_decorated_function(self) -> None:
+        @factory
+        def create_repo() -> Repository:
+            return Repository()
+
+        mod = types.ModuleType("test_scan_fn")
+        mod.create_repo = create_repo  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(Repository), Repository)
+
+    def test_scan_factory_resolves_dependencies(self) -> None:
+        @factory
+        def make_service(repo: Repository) -> UserService:
+            return UserService(repo)
+
+        mod = types.ModuleType("test_scan_fn_deps")
+        mod.make_service = make_service  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.register(Repository)
+        c.scan(mod)
+        svc = c.get(UserService)
+        assert isinstance(svc, UserService)
+        assert isinstance(svc.repo, Repository)
+
+    def test_scan_factory_explicit_provides(self) -> None:
+        class Base:
+            pass
+
+        class Impl(Base):
+            pass
+
+        @factory(provides=Base)
+        def create_impl() -> Impl:
+            return Impl()
+
+        mod = types.ModuleType("test_scan_fn_provides")
+        mod.create_impl = create_impl  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(Base), Impl)
+
+    def test_scan_factory_with_scope(self) -> None:
+        @factory(scope=Scope.TRANSIENT)
+        def create_repo() -> Repository:
+            return Repository()
+
+        mod = types.ModuleType("test_scan_fn_scope")
+        mod.create_repo = create_repo  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        r1 = c.get(Repository)
+        r2 = c.get(Repository)
+        assert r1 is not r2
+
+    def test_scan_factory_with_qualifier(self) -> None:
+        @factory(qualifier="primary")
+        def create_repo() -> Repository:
+            return Repository()
+
+        mod = types.ModuleType("test_scan_fn_qual")
+        mod.create_repo = create_repo  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(Repository, qualifier="primary"), Repository)
+
+    def test_scan_raises_for_factory_without_return_type(self) -> None:
+        @factory
+        def create():  # noqa: ANN202
+            return Repository()
+
+        mod = types.ModuleType("test_scan_fn_no_ret")
+        mod.create = create  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        with pytest.raises(TypeError, match="return type annotation"):
+            c.scan(mod)
+
+    def test_scan_factory_validates_dependencies(self) -> None:
+        @factory
+        def make_service(repo: Repository) -> UserService:
+            return UserService(repo)
+
+        mod = types.ModuleType("test_scan_fn_validate")
+        mod.make_service = make_service  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        with pytest.raises(DependencyResolutionError):
+            c.validate()
+
+
+class TestScanFactoryClassmethods:
+    def test_scan_finds_factory_classmethod(self) -> None:
+        class RepoFactory:
+            @factory
+            @classmethod
+            def create(cls) -> Repository:
+                return Repository()
+
+        mod = types.ModuleType("test_scan_cm")
+        mod.RepoFactory = RepoFactory  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(Repository), Repository)
+
+    def test_scan_classmethod_other_ordering(self) -> None:
+        class RepoFactory:
+            @classmethod
+            @factory
+            def create(cls) -> Repository:
+                return Repository()
+
+        mod = types.ModuleType("test_scan_cm_order")
+        mod.RepoFactory = RepoFactory  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(Repository), Repository)
+
+    def test_scan_classmethod_resolves_dependencies(self) -> None:
+        class ServiceFactory:
+            @factory
+            @classmethod
+            def create(cls, repo: Repository) -> UserService:
+                return UserService(repo)
+
+        mod = types.ModuleType("test_scan_cm_deps")
+        mod.ServiceFactory = ServiceFactory  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.register(Repository)
+        c.scan(mod)
+        svc = c.get(UserService)
+        assert isinstance(svc, UserService)
+        assert isinstance(svc.repo, Repository)
+
+    def test_scan_classmethod_with_provides(self) -> None:
+        class Base:
+            pass
+
+        class Impl(Base):
+            @factory(provides=Base)
+            @classmethod
+            def create(cls) -> Base:
+                return Impl()
+
+        mod = types.ModuleType("test_scan_cm_provides")
+        mod.Impl = Impl  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(Base), Impl)
+
+    def test_class_component_and_classmethod_factory_coexist(self) -> None:
+        @component
+        class Impl:
+            pass
+
+        class ImplFactory:
+            @factory(qualifier="custom")
+            @classmethod
+            def create(cls) -> Impl:
+                return Impl()
+
+        mod = types.ModuleType("test_scan_coexist")
+        mod.Impl = Impl  # ty: ignore[unresolved-attribute]
+        mod.ImplFactory = ImplFactory  # ty: ignore[unresolved-attribute]
+
+        c = Container()
+        c.scan(mod)
+        assert isinstance(c.get(Impl), Impl)
+        assert isinstance(c.get(Impl, qualifier="custom"), Impl)


### PR DESCRIPTION
## Summary

- Adds a `@factory` decorator (distinct from `@component`) for marking functions and classmethods as DI-managed factories, discoverable by `scan()`
- Return type annotation determines the provided type; `provides=` overrides when the interface differs
- Both `@factory @classmethod` and `@classmethod @factory` orderings work
- `scan()` discovers decorated module-level functions and classmethods on classes
- Missing return annotation without `provides=` raises `TypeError` at scan time
- Uses `@factory` in the example app's `SqliteUserRepository` to separate construction from the class

## Test plan

- [x] 10 decorator tests: bare/parameterized on functions and classmethods, both orderings
- [x] 12 scan/integration tests: discovery, dependency resolution, provides override, scope, qualifier, error on missing return type, graph validation, coexistence with `@component`
- [x] Example app integration tests still pass with the `@factory` classmethod
- [x] All checks pass: ty, ruff, format, 371 tests, 96% coverage

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)