### PR TITLE
Simplify internal implementation (-47 lines)

### DIFF
--- a/src/uncoiled/_component.py
+++ b/src/uncoiled/_component.py
@@ -22,6 +22,25 @@ class ComponentMetadata:
     provides: type | None = None
 
 
+def _attach(target: object, meta: ComponentMetadata) -> object:
+    """Attach metadata to any decorator target (class, function, or classmethod)."""
+    if isinstance(target, classmethod):
+        target.__func__.__uncoiled__ = meta  # ty: ignore[unresolved-attribute]
+    else:
+        target.__uncoiled__ = meta  # ty: ignore[invalid-assignment]
+    return target
+
+
+class _Decorator:
+    """Callable returned by ``@component(...)`` or ``@factory(...)`` with arguments."""
+
+    def __init__(self, meta: ComponentMetadata) -> None:
+        self._meta = meta
+
+    def __call__(self, target: object) -> object:
+        return _attach(target, self._meta)
+
+
 # region @component — marks a class for constructor injection
 
 
@@ -35,7 +54,7 @@ def component(
     scope: Scope = ...,
     qualifier: str | None = ...,
     provides: type | None = ...,
-) -> _ComponentDecorator: ...
+) -> _Decorator: ...
 
 
 def component(
@@ -45,7 +64,7 @@ def component(
     scope: Scope = Scope.SINGLETON,
     qualifier: str | None = None,
     provides: type | None = None,
-) -> type | _ComponentDecorator:
+) -> type | _Decorator:
     """Mark a class as a DI-managed component.
 
     Can be used with or without arguments::
@@ -65,38 +84,15 @@ def component(
     meta = ComponentMetadata(scope=scope, qualifier=qualifier, provides=provides)
 
     if cls is not None:
-        cls.__uncoiled__ = meta  # ty: ignore[unresolved-attribute]
+        _attach(cls, meta)
         return cls
 
-    return _ComponentDecorator(meta)
-
-
-class _ComponentDecorator:
-    """Callable returned by ``@component(...)`` with arguments."""
-
-    def __init__(self, meta: ComponentMetadata) -> None:
-        self._meta = meta
-
-    def __call__(self, cls: type) -> type:
-        cls.__uncoiled__ = self._meta  # ty: ignore[unresolved-attribute]
-        return cls
+    return _Decorator(meta)
 
 
 # endregion
 
 # region @factory — marks a function or classmethod as a DI-managed factory
-
-
-def _apply_factory_metadata(
-    target: _FactoryTarget,
-    meta: ComponentMetadata,
-) -> _FactoryTarget:
-    """Attach metadata to a factory function or classmethod descriptor."""
-    if isinstance(target, classmethod):
-        target.__func__.__uncoiled__ = meta  # ty: ignore[unresolved-attribute]
-    else:
-        target.__uncoiled__ = meta  # ty: ignore[invalid-assignment]
-    return target
 
 
 @overload
@@ -109,7 +105,7 @@ def factory(
     scope: Scope = ...,
     qualifier: str | None = ...,
     provides: type | None = ...,
-) -> _FactoryDecorator: ...
+) -> _Decorator: ...
 
 
 def factory(
@@ -119,7 +115,7 @@ def factory(
     scope: Scope = Scope.SINGLETON,
     qualifier: str | None = None,
     provides: type | None = None,
-) -> _FactoryTarget | _FactoryDecorator:
+) -> _FactoryTarget | _Decorator:
     """Mark a function or classmethod as a DI-managed factory.
 
     Can be used with or without arguments::
@@ -144,19 +140,10 @@ def factory(
     meta = ComponentMetadata(scope=scope, qualifier=qualifier, provides=provides)
 
     if target is not None:
-        return _apply_factory_metadata(target, meta)
+        _attach(target, meta)
+        return target
 
-    return _FactoryDecorator(meta)
-
-
-class _FactoryDecorator:
-    """Callable returned by ``@factory(...)`` with arguments."""
-
-    def __init__(self, meta: ComponentMetadata) -> None:
-        self._meta = meta
-
-    def __call__(self, target: _FactoryTarget) -> _FactoryTarget:
-        return _apply_factory_metadata(target, self._meta)
+    return _Decorator(meta)
 
 
 # endregion

--- a/src/uncoiled/_config/_binding.py
+++ b/src/uncoiled/_config/_binding.py
@@ -61,11 +61,9 @@ def bind_config[T](cls: type[T], source: ConfigSource) -> T:
                 msg = f"Cannot coerce config key '{key}' value {raw!r} to {type_name}"
                 raise ValueError(msg) from exc
         elif (
-            field.default is not dataclasses.MISSING
-            or field.default_factory is not dataclasses.MISSING
+            field.default is dataclasses.MISSING
+            and field.default_factory is dataclasses.MISSING
         ):
-            pass  # Let the dataclass use its default
-        else:
             msg = f"Missing required config value for '{key}'"
             raise ValueError(msg)
 

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -23,10 +23,6 @@ class ComponentNode:
     factory: object | None = None
 
 
-def _type_key(typ: type, qualifier: str | None = None) -> tuple[type, str | None]:
-    return (typ, qualifier)
-
-
 def build_graph(
     registrations: dict[tuple[type, str | None], ComponentNode],
 ) -> list[ResolutionFailure]:
@@ -36,10 +32,6 @@ def build_graph(
     Collects all failures rather than stopping at the first.
     """
     failures: list[ResolutionFailure] = []
-
-    all_providers: dict[type, list[ComponentNode]] = defaultdict(list)
-    for node in registrations.values():
-        all_providers[node.provides].append(node)
 
     adj: dict[tuple[type, str | None], set[tuple[type, str | None]]] = defaultdict(set)
     in_degree: dict[tuple[type, str | None], int] = {}
@@ -51,7 +43,7 @@ def build_graph(
         target = node.factory if node.factory is not None else node.impl
         node.dependencies = inspect_dependencies(target)
         for dep in node.dependencies:
-            dep_key = _type_key(dep.required_type, dep.qualifier)
+            dep_key = (dep.required_type, dep.qualifier)
 
             if (
                 dep.is_list

--- a/src/uncoiled/_inspection.py
+++ b/src/uncoiled/_inspection.py
@@ -112,43 +112,19 @@ def _resolve_annotation(
     has_default: bool,
 ) -> DependencySpec | None:
     """Resolve a single annotation into a DependencySpec."""
-    origin = get_origin(annotation)
-
-    if origin is Annotated:
+    if get_origin(annotation) is Annotated:
         return _resolve_annotated(
             name,
             get_args(annotation),
             has_default=has_default,
         )
 
-    if origin is list:
-        args = get_args(annotation)
-        if args:
-            return DependencySpec(
-                name=name,
-                required_type=args[0],
-                is_list=True,
-                has_default=has_default,
-            )
-        return None
-
-    inner = _is_optional_union(annotation)
-    if inner is not None:
-        return DependencySpec(
-            name=name,
-            required_type=inner,
-            optional=True,
-            has_default=has_default,
-        )
-
-    if isinstance(annotation, type):
-        return DependencySpec(
-            name=name,
-            required_type=annotation,
-            has_default=has_default,
-        )
-
-    return None
+    return _resolve_annotation_with_qualifier(
+        name,
+        annotation,
+        qualifier=None,
+        has_default=has_default,
+    )
 
 
 def _resolve_annotation_with_qualifier(


### PR DESCRIPTION
## Summary

- **`_component.py`**: Unify `_ComponentDecorator` and `_FactoryDecorator` into a shared `_attach()` function and `_Decorator` class — both decorators had identical internal logic
- **`_graph.py`**: Remove dead `all_providers` dict (leftover from removed `AMBIGUOUS` detection, #116) and inline the trivial `_type_key()` helper (called once)
- **`_inspection.py`**: Eliminate duplicate annotation resolution — `_resolve_annotation` now delegates to `_resolve_annotation_with_qualifier` for non-`Annotated` cases instead of reimplementing the same optional/list/plain-type checks
- **`_config/_binding.py`**: Invert condition in `bind_config` to remove unnecessary `pass` branch

Net -47 lines, no behavior changes. Coverage improved on `_graph.py` (dead code was uncovered).

## Test plan

- [x] 371 tests pass
- [x] ty, ruff, format all clean
- [x] Coverage: `_component.py` 100%, `_graph.py` 100% (improved), `_inspection.py` 99%, `_binding.py` 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)