### PR TITLE
Add Sphinx documentation with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+---
+name: Docs
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "astral-sh/setup-uv@v7"
+        with:
+          python-version: "3.14"
+      - run: "uv sync --group docs"
+      - run: "uv run sphinx-build -b html docs docs/_build/html -W"
+      - uses: "actions/upload-pages-artifact@v3"
+        with:
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: "actions/deploy-pages@v4"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 wheels/
 *.egg-info
 
+# Docs build
+docs/_build/
+
 # Testing data
 coverage/
 mutation/

--- a/docs/api/configuration.rst
+++ b/docs/api/configuration.rst
@@ -1,0 +1,40 @@
+Configuration
+=============
+
+Sources
+-------
+
+.. autoclass:: uncoiled.ConfigSource
+   :members:
+
+.. autoclass:: uncoiled.DictSource
+   :members:
+
+.. autoclass:: uncoiled.EnvSource
+   :members:
+
+.. autoclass:: uncoiled.DotEnvSource
+   :members:
+
+.. autoclass:: uncoiled.YamlSource
+   :members:
+
+.. autoclass:: uncoiled.LayeredSource
+   :members:
+
+Binding
+-------
+
+.. autodecorator:: uncoiled.config_properties
+
+.. autofunction:: uncoiled.bind_config
+
+Profiles
+--------
+
+.. autofunction:: uncoiled.get_active_profiles
+
+Key Normalisation
+-----------------
+
+.. autofunction:: uncoiled.normalise

--- a/docs/api/container.rst
+++ b/docs/api/container.rst
@@ -1,0 +1,22 @@
+Container
+=========
+
+.. autoclass:: uncoiled.Container
+   :members:
+   :undoc-members:
+
+.. autoclass:: uncoiled.Scope
+   :members:
+   :undoc-members:
+
+.. autoclass:: uncoiled.ComponentNode
+   :members:
+
+.. autoclass:: uncoiled.DependencySpec
+   :members:
+
+.. autofunction:: uncoiled.inspect_dependencies
+
+.. autofunction:: uncoiled.build_graph
+
+.. autofunction:: uncoiled.validate_graph

--- a/docs/api/decorators.rst
+++ b/docs/api/decorators.rst
@@ -1,0 +1,15 @@
+Decorators
+==========
+
+.. autofunction:: uncoiled.component
+
+.. autofunction:: uncoiled.factory
+
+.. autoclass:: uncoiled.ComponentMetadata
+   :members:
+
+.. autoclass:: uncoiled.Qualifier
+   :members:
+
+.. autoclass:: uncoiled.EnvVar
+   :members:

--- a/docs/api/errors.rst
+++ b/docs/api/errors.rst
@@ -1,0 +1,13 @@
+Errors
+======
+
+.. autoclass:: uncoiled.DependencyResolutionError
+   :members:
+   :show-inheritance:
+
+.. autoclass:: uncoiled.ResolutionFailure
+   :members:
+
+.. autoclass:: uncoiled.FailureKind
+   :members:
+   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,24 @@
+"""Sphinx configuration for uncoiled documentation."""
+
+project = "uncoiled"
+copyright = "2026, Jonathan Sharpe"  # noqa: A001
+author = "Jonathan Sharpe"
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx_copybutton",
+]
+
+html_theme = "furo"
+html_title = "uncoiled"
+
+autodoc_member_order = "bysource"
+autodoc_typehints = "description"
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+exclude_patterns = ["_build"]

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,0 +1,84 @@
+Getting Started
+===============
+
+Installation
+------------
+
+.. code-block:: bash
+
+   pip install uncoiled
+
+For optional integrations:
+
+.. code-block:: bash
+
+   pip install uncoiled[fastapi]   # FastAPI support
+   pip install uncoiled[yaml]      # YAML config sources
+
+Core Concepts
+-------------
+
+Uncoiled wires dependencies by inspecting ``__init__`` signatures.  Your
+classes never import the framework --- they just declare what they need via
+standard type annotations.
+
+**Container** manages registration, validation, and resolution:
+
+.. code-block:: python
+
+   from uncoiled import Container
+
+   c = Container()
+   c.register(UserRepository)
+   c.register(UserService)
+   c.start()
+
+   service = c.get(UserService)
+
+**@component** marks a class for automatic discovery via ``scan()``:
+
+.. code-block:: python
+
+   from uncoiled import component
+
+   @component
+   class UserService:
+       def __init__(self, repo: UserRepository) -> None:
+           self.repo = repo
+
+   c = Container()
+   c.scan("myapp")  # discovers all @component classes
+   c.start()
+
+**@factory** marks a function or classmethod as a factory:
+
+.. code-block:: python
+
+   from uncoiled import factory
+
+   @factory
+   def create_client(config: HttpConfig) -> HttpClient:
+       return HttpClient(timeout=config.timeout)
+
+Validation
+----------
+
+Call :meth:`~uncoiled.Container.validate` to eagerly detect problems before
+starting:
+
+.. code-block:: python
+
+   c = Container()
+   c.register(UserService)
+   # UserRepository not registered --- validate catches it
+   c.validate()  # raises DependencyResolutionError
+
+The error message lists every failure with suggestions:
+
+.. code-block:: text
+
+   Cannot build dependency graph (1 failure):
+     1. Missing dependency for UserService.__init__: parameter 'repo'
+        requires type 'UserRepository', but no matching component is
+        registered.
+        Suggestion: Register a component of type UserRepository.

--- a/docs/guide/components.rst
+++ b/docs/guide/components.rst
@@ -1,0 +1,171 @@
+Components and Factories
+========================
+
+``@component``
+--------------
+
+The :func:`~uncoiled.component` decorator marks a class for constructor
+injection.  The container inspects the class's ``__init__`` to discover
+dependencies:
+
+.. code-block:: python
+
+   from uncoiled import component, Scope
+
+   @component
+   class UserService:
+       def __init__(self, repo: UserRepository) -> None:
+           self.repo = repo
+
+   @component(scope=Scope.TRANSIENT)
+   class RequestHandler:
+       def __init__(self, service: UserService) -> None:
+           self.service = service
+
+   @component(provides=UserRepository)
+   class PostgresRepository:
+       def __init__(self, config: DbConfig) -> None:
+           ...
+
+Options:
+
+- ``scope`` --- lifecycle scope (default: ``Scope.SINGLETON``)
+- ``qualifier`` --- disambiguate multiple implementations of the same type
+- ``provides`` --- register under an interface type instead of the concrete class
+
+``@factory``
+------------
+
+The :func:`~uncoiled.factory` decorator marks a function or classmethod as a
+factory.  Dependencies are introspected from the function's parameters, and the
+return type annotation determines the provided type:
+
+.. code-block:: python
+
+   from uncoiled import factory
+
+   @factory
+   def create_client(config: HttpConfig) -> HttpClient:
+       return HttpClient(timeout=config.timeout)
+
+Factory classmethods work with either decorator ordering:
+
+.. code-block:: python
+
+   class SqliteRepository:
+       def __init__(self, conn: sqlite3.Connection) -> None:
+           self._conn = conn
+
+       @classmethod
+       @factory
+       def create(cls, config: DbConfig) -> UserRepository:
+           conn = sqlite3.connect(config.url)
+           return cls(conn)
+
+Use ``provides=`` to override the return annotation when the interface differs
+from the concrete type.
+
+Scanning
+--------
+
+:meth:`~uncoiled.Container.scan` discovers all ``@component`` and ``@factory``
+decorations in a module and its subpackages:
+
+.. code-block:: python
+
+   c = Container()
+   c.scan("myapp")          # by module name
+   c.scan(myapp.infra)      # by module object
+
+Manual Registration
+-------------------
+
+For types you don't control, register them imperatively:
+
+.. code-block:: python
+
+   c.register(ThirdPartyService)
+   c.register_instance(existing_object)
+   c.register_factory(create_session, return_type=Session)
+
+Qualifiers
+----------
+
+When multiple implementations of the same type exist, use
+:class:`~uncoiled.Qualifier` to disambiguate:
+
+.. code-block:: python
+
+   from typing import Annotated
+   from uncoiled import Qualifier
+
+   @component(qualifier="primary")
+   class PrimaryDb(Database):
+       ...
+
+   @component(qualifier="replica")
+   class ReplicaDb(Database):
+       ...
+
+   class Service:
+       def __init__(
+           self,
+           db: Annotated[Database, Qualifier("primary")],
+       ) -> None:
+           self.db = db
+
+Optional and List Dependencies
+------------------------------
+
+Optional dependencies resolve to ``None`` when not registered:
+
+.. code-block:: python
+
+   class Service:
+       def __init__(self, cache: Cache | None = None) -> None:
+           self.cache = cache
+
+List dependencies collect all implementations:
+
+.. code-block:: python
+
+   class EventBus:
+       def __init__(self, handlers: list[EventHandler]) -> None:
+           self.handlers = handlers
+
+Environment Variables
+---------------------
+
+:class:`~uncoiled.EnvVar` injects values directly from the environment:
+
+.. code-block:: python
+
+   from typing import Annotated
+   from uncoiled import EnvVar
+
+   class Service:
+       def __init__(
+           self,
+           db_url: Annotated[str, EnvVar("DATABASE_URL")] = ":memory:",
+       ) -> None:
+           self.db_url = db_url
+
+Supported coercion types: ``str``, ``int``, ``float``, ``bool``, ``Path``.
+
+Logger Injection
+----------------
+
+``logging.Logger`` is auto-injected without registration, named after the
+component's module:
+
+.. code-block:: python
+
+   import logging
+
+   @component
+   class Service:
+       def __init__(self, logger: logging.Logger) -> None:
+           self.logger = logger
+       # logger.name == "myapp.service"
+
+Register a ``Logger`` explicitly to override auto-injection.

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -1,0 +1,92 @@
+Configuration
+=============
+
+Uncoiled provides a layered configuration system inspired by Spring Boot.
+
+Config Properties
+-----------------
+
+Bind a prefix to a frozen dataclass with
+:func:`~uncoiled.config_properties`:
+
+.. code-block:: python
+
+   from dataclasses import dataclass
+   from uncoiled import config_properties
+
+   @config_properties("db")
+   @dataclass(frozen=True)
+   class DbConfig:
+       host: str = "localhost"
+       port: int = 5432
+       url: str = ":memory:"
+
+Then bind it from a source at startup:
+
+.. code-block:: python
+
+   from uncoiled import EnvSource, bind_config, Container
+
+   config = bind_config(DbConfig, EnvSource())
+   c = Container()
+   c.register_instance(config)
+
+With ``DB_HOST=postgres`` in the environment, ``config.host`` resolves to
+``"postgres"`` and ``config.port`` uses its default ``5432``.
+
+Configuration Sources
+---------------------
+
+All sources implement the :class:`~uncoiled.ConfigSource` protocol:
+
+:class:`~uncoiled.DictSource`
+   In-memory dictionary.
+
+:class:`~uncoiled.EnvSource`
+   Reads from environment variables. Tries the normalised key first, then the
+   uppercase/underscore form (``db.host`` -> ``DB_HOST``).
+
+:class:`~uncoiled.DotEnvSource`
+   Parses a ``.env`` file. Handles quoted values.
+
+:class:`~uncoiled.YamlSource`
+   Reads a YAML file (requires ``uncoiled[yaml]``). Nested keys are flattened
+   with dots.
+
+:class:`~uncoiled.LayeredSource`
+   Chains multiple sources with first-match-wins precedence:
+
+   .. code-block:: python
+
+      from uncoiled import LayeredSource, EnvSource, DotEnvSource, YamlSource
+
+      source = LayeredSource(
+          EnvSource(),
+          DotEnvSource(".env"),
+          YamlSource("config.yml"),
+      )
+
+Relaxed Binding
+---------------
+
+Keys are normalised so that all of these refer to the same value:
+
+- ``db.host``
+- ``DB_HOST``
+- ``db-host``
+
+Profiles
+--------
+
+Set ``UNCOILED_PROFILES=dev,local`` to activate profiles.  Use
+:func:`~uncoiled.get_active_profiles` to conditionally register components:
+
+.. code-block:: python
+
+   from uncoiled import get_active_profiles
+
+   profiles = get_active_profiles()
+   if "dev" in profiles:
+       c.register(MockMailer, provides=Mailer)
+   else:
+       c.register(SmtpMailer, provides=Mailer)

--- a/docs/guide/fastapi.rst
+++ b/docs/guide/fastapi.rst
@@ -1,0 +1,84 @@
+FastAPI Integration
+===================
+
+Install with ``pip install uncoiled[fastapi]``.
+
+Inject[T]
+---------
+
+Use ``Inject[T]`` in route signatures to resolve from the container:
+
+.. code-block:: python
+
+   from uncoiled.fastapi import Inject
+
+   @app.get("/users")
+   def list_users(controller: Inject[UserController]):
+       return controller.list_all()
+
+This is a type alias for ``Annotated[T, Depends(...)]`` --- FastAPI handles it
+natively.
+
+Application Setup
+-----------------
+
+Wire the container into a FastAPI app using the lifespan and middleware:
+
+.. code-block:: python
+
+   from fastapi import FastAPI
+   from uncoiled import Container, EnvSource, bind_config
+   from uncoiled.fastapi import (
+       RequestScopeMiddleware,
+       RequestValueProvider,
+       uncoiled_lifespan,
+   )
+
+   def create_app() -> FastAPI:
+       c = Container()
+       c.register_instance(bind_config(DbConfig, EnvSource()))
+       c.scan("myapp")
+
+       app = FastAPI(lifespan=uncoiled_lifespan(c))
+       app.add_middleware(
+           RequestScopeMiddleware,
+           container=c,
+           request_values=[
+               RequestValueProvider(
+                   TenantId,
+                   lambda r: TenantId(r.headers["x-tenant-id"]),
+               ),
+           ],
+       )
+       return app
+
+Request Values
+--------------
+
+:class:`~uncoiled.fastapi.RequestValueProvider` extracts values from each HTTP
+request and seeds them into the request scope:
+
+.. code-block:: python
+
+   RequestValueProvider(
+       TenantId,
+       lambda request: TenantId(request.headers.get("x-tenant-id", "default")),
+   )
+
+These values are then injectable into request-scoped components via normal
+constructor injection.
+
+Testing
+-------
+
+Pass a test container to the app factory so tests use the same routes and
+middleware:
+
+.. code-block:: python
+
+   def test_app():
+       c = Container()
+       c.scan("myapp")
+       c.register(MockRepo, provides=UserRepository, replace=True)
+       app = create_app(c)
+       # use httpx.AsyncClient with ASGITransport

--- a/docs/guide/scopes.rst
+++ b/docs/guide/scopes.rst
@@ -1,0 +1,86 @@
+Scopes
+======
+
+Every component has a lifecycle scope that controls how instances are cached.
+
+Singleton (default)
+-------------------
+
+One instance per container lifetime.  Created on first access, reused
+thereafter:
+
+.. code-block:: python
+
+   from uncoiled import component, Scope
+
+   @component  # scope=Scope.SINGLETON is the default
+   class DatabasePool:
+       ...
+
+Transient
+---------
+
+A new instance on every resolution --- nothing is cached:
+
+.. code-block:: python
+
+   @component(scope=Scope.TRANSIENT)
+   class RequestHandler:
+       ...
+
+Request
+-------
+
+One instance per HTTP request.  Requires
+:class:`~uncoiled.fastapi.RequestScopeMiddleware` (or manual use of
+:meth:`~uncoiled.Container.request_context`):
+
+.. code-block:: python
+
+   @component(scope=Scope.REQUEST)
+   class UserController:
+       def __init__(self, repo: UserRepository, tenant: TenantId) -> None:
+           ...
+
+Request-scoped values are isolated via ``contextvars``, so concurrent requests
+each get their own instance.
+
+Scope Validation
+----------------
+
+The dependency graph validates scope compatibility eagerly.  A singleton
+depending on a request-scoped component is rejected:
+
+.. code-block:: text
+
+   Singleton 'CachedService' depends on request-scoped 'TenantId' ---
+   singletons cannot depend on request-scoped components because they
+   are created at startup before any request context exists.
+
+Lifecycle Hooks
+---------------
+
+Register init and destroy methods to run during
+:meth:`~uncoiled.Container.start` / :meth:`~uncoiled.Container.close`:
+
+.. code-block:: python
+
+   c.register(
+       ConnectionPool,
+       init_method="connect",
+       destroy_method="disconnect",
+   )
+
+   with c:  # calls start() on enter, close() on exit
+       pool = c.get(ConnectionPool)
+       # pool.connect() was called
+
+Generator factories handle cleanup automatically:
+
+.. code-block:: python
+
+   @factory
+   def create_session(pool: ConnectionPool) -> Session:
+       session = pool.checkout()
+       yield session
+       session.close()

--- a/docs/guide/testing.rst
+++ b/docs/guide/testing.rst
@@ -1,0 +1,92 @@
+Testing
+=======
+
+Uncoiled provides several mechanisms for testing with dependency injection.
+
+Override Context Manager
+------------------------
+
+:meth:`~uncoiled.Container.override` temporarily replaces a registration:
+
+.. code-block:: python
+
+   mock_repo = MockUserRepository()
+   with container.override(UserRepository, mock_repo):
+       service = container.get(UserService)
+       assert isinstance(service.repo, MockUserRepository)
+   # original registration restored
+
+Fork
+----
+
+:meth:`~uncoiled.Container.fork` creates a child container that inherits all
+registrations but can override them independently:
+
+.. code-block:: python
+
+   child = container.fork()
+   child.register(MockMailer, provides=Mailer, replace=True)
+   # parent container is unaffected
+
+Pytest Plugin
+-------------
+
+The built-in pytest plugin (auto-discovered via entry point) provides:
+
+**Fixtures:**
+
+- ``uncoiled_container`` (session-scoped) --- a started container
+- ``inject`` (function-scoped) --- a :class:`~uncoiled.Resolve` helper
+
+**Usage:**
+
+.. code-block:: python
+
+   def test_user_service(inject):
+       service = inject[UserService]
+       assert isinstance(service.repo, UserRepository)
+
+**Override marker:**
+
+.. code-block:: python
+
+   import pytest
+   from uncoiled import Resolve
+
+   @pytest.mark.uncoiled_override(UserRepository, MockRepository)
+   def test_with_mock(inject: Resolve):
+       service = inject[UserService]
+       assert isinstance(service.repo, MockRepository)
+
+The marker accepts an optional ``qualifier`` keyword argument.
+
+Setup
+^^^^^
+
+To use the plugin, define a ``uncoiled_container`` fixture in your
+``conftest.py`` that builds and yields your container:
+
+.. code-block:: python
+
+   import pytest
+   from uncoiled import Container
+
+   @pytest.fixture(scope="session")
+   def uncoiled_container():
+       c = Container()
+       c.scan("myapp")
+       with c:
+           yield c
+
+Unit Tests Without the Framework
+---------------------------------
+
+Because components use plain constructor injection, unit tests can
+instantiate classes directly without any DI framework:
+
+.. code-block:: python
+
+   def test_user_service():
+       repo = MockUserRepository()
+       service = UserService(repo)
+       assert service.create_user("Alice").name == "Alice"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,48 @@
+uncoiled
+========
+
+Dependency injection for modern Python.
+
+Uncoiled is a dependency injection framework that resolves dependencies from
+``__init__`` type annotations --- no markers, no framework imports in your
+business code.
+
+.. code-block:: python
+
+   from uncoiled import Container, component
+
+   class UserRepository:
+       pass
+
+   @component
+   class UserService:
+       def __init__(self, repo: UserRepository) -> None:
+           self.repo = repo
+
+   c = Container()
+   c.register(UserRepository)
+   c.scan(__import__(__name__))
+   c.start()
+
+   service = c.get(UserService)
+   assert isinstance(service.repo, UserRepository)
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   getting-started
+   guide/components
+   guide/configuration
+   guide/scopes
+   guide/testing
+   guide/fastapi
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   api/container
+   api/decorators
+   api/configuration
+   api/errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ lint = [
     "ruff>=0.15.6",
     "ty>=0.0.23",
 ]
+docs = [
+    "furo>=2024.8.6",
+    "sphinx>=8.0",
+    "sphinx-copybutton>=0.5",
+]
 mutation = [
     "cosmic-ray>=8.4.4",
     "tqdm>=4.67.3",
@@ -79,4 +84,7 @@ ignore = [
     "D",
     "PLR2004",
     "S101",
+]
+"docs/**" = [
+    "INP001",
 ]


### PR DESCRIPTION
## Summary

- Adds Sphinx documentation with the Furo theme, autodoc, intersphinx, and sphinx-copybutton
- User guide: getting started, components/factories, configuration, scopes, testing, FastAPI integration
- API reference: autodoc-generated from existing docstrings (container, decorators, configuration, errors)
- GitHub Actions workflow builds docs on push to main and deploys to GitHub Pages
- Adds `docs` dependency group (sphinx, furo, sphinx-copybutton) to pyproject.toml

## Structure

```
docs/
├── conf.py
├── index.rst
├── getting-started.rst
├── guide/
│   ├── components.rst
│   ├── configuration.rst
│   ├── scopes.rst
│   ├── testing.rst
│   └── fastapi.rst
└── api/
    ├── container.rst
    ├── decorators.rst
    ├── configuration.rst
    └── errors.rst
```

## Test plan

- [x] `sphinx-build -W` (warnings as errors) passes cleanly
- [x] ruff, format, 371 tests all pass
- [x] Docs workflow deploys on push to main only (not on PRs)

Note: GitHub Pages needs to be enabled in repo settings (Settings > Pages > Source: GitHub Actions) for the deployment to work.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)