### PR TITLE
Fix type annotations for mypy/pyright compliance

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,11 +26,7 @@ jobs:
       - run: "uv run ty check"
       - run: "uv run ruff check"
       - run: "uv run ruff format --check"
-      - name: "mypy (informational)"
-        run: "uv run mypy src/uncoiled/ --ignore-missing-imports"
-        continue-on-error: true
-      - name: "pyright (informational)"
-        run: "uv run pyright src/uncoiled/"
-        continue-on-error: true
+      - run: "uv run mypy src/uncoiled/"
+      - run: "uv run pyright src/uncoiled/"
       - run: "uv run coverage run --module pytest"
       - run: "uv run coverage report"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ lint = [
     "pyright>=1.1",
     "ruff>=0.15.6",
     "ty>=0.0.23",
+    "types-pyyaml>=6.0",
 ]
 docs = [
     "furo>=2024.8.6",

--- a/src/uncoiled/_coercion.py
+++ b/src/uncoiled/_coercion.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _BOOL_TRUE = frozenset({"1", "on", "true", "yes"})
 _BOOL_FALSE = frozenset({"0", "false", "no", "off"})
@@ -19,7 +23,7 @@ def _parse_bool(value: str) -> bool:
     raise ValueError(msg)
 
 
-_COERCIONS: dict[type, object] = {
+_COERCIONS: dict[type, Callable[[str], object]] = {
     str: str,
     int: int,
     float: float,
@@ -45,7 +49,7 @@ def coerce(value: str, target: type) -> object:
 
     coercer = _COERCIONS.get(target)
     if coercer is not None:
-        return coercer(value)  # ty: ignore[call-non-callable]
+        return coercer(value)
 
     msg = f"Unsupported coercion target type: {target}"
     raise ValueError(msg)

--- a/src/uncoiled/_component.py
+++ b/src/uncoiled/_component.py
@@ -25,9 +25,9 @@ class ComponentMetadata:
 def _attach(target: object, meta: ComponentMetadata) -> object:
     """Attach metadata to any decorator target (class, function, or classmethod)."""
     if isinstance(target, classmethod):
-        target.__func__.__uncoiled__ = meta  # ty: ignore[unresolved-attribute]
+        target.__func__.__uncoiled__ = meta  # type: ignore[attr-defined]
     else:
-        target.__uncoiled__ = meta  # ty: ignore[invalid-assignment]
+        target.__uncoiled__ = meta  # type: ignore[attr-defined]
     return target
 
 

--- a/src/uncoiled/_config/_binding.py
+++ b/src/uncoiled/_config/_binding.py
@@ -38,7 +38,7 @@ class _ConfigPropertiesDecorator:
 
     def __call__(self, cls: type) -> type:
         """Attach prefix metadata to the class."""
-        cls.__config_prefix__ = self._prefix  # ty: ignore[unresolved-attribute]
+        cls.__config_prefix__ = self._prefix  # type: ignore[attr-defined]
         return cls
 
 
@@ -46,7 +46,7 @@ def bind_config[T](cls: type[T], source: ConfigSource) -> T:
     """Create an instance of a config dataclass by reading values from a source."""
     prefix = getattr(cls, "__config_prefix__", "")
     hints = get_type_hints(cls)
-    fields = dataclasses.fields(cls)
+    fields = dataclasses.fields(cls)  # type: ignore[arg-type]
     kwargs: dict[str, object] = {}
 
     for field in fields:

--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -8,7 +8,7 @@ import inspect
 import logging
 import os
 import pkgutil
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any, Self, cast
 
 from ._coercion import coerce
 from ._graph import ComponentNode, validate_graph
@@ -18,14 +18,17 @@ from ._scope import RequestScope, SingletonScope, TransientScope
 from ._types import Scope
 
 if TYPE_CHECKING:
+    import types
     from collections.abc import Callable, Iterator
     from types import ModuleType
 
     from ._component import ComponentMetadata
     from ._scope import ScopeManager
 
+    _Generator = types.GeneratorType[Any, Any, Any] | types.AsyncGeneratorType[Any, Any]
 
-_REQUEST_VALUE_SENTINEL = object()
+
+_REQUEST_VALUE_SENTINEL: Callable[..., object] = cast("Callable[..., object]", object())
 
 
 def _infer_return_type(fn: Callable[..., object]) -> type:
@@ -56,7 +59,7 @@ class Container:
             Scope.REQUEST: RequestScope(),
         }
         self._instances: list[tuple[object, type, str | None]] = []
-        self._generators: list[object] = []
+        self._generators: list[_Generator] = []
         self._destroy_hooks: dict[tuple[type, str | None], str | None] = {}
         self._init_hooks: dict[tuple[type, str | None], str | None] = {}
         self._started = False
@@ -117,7 +120,7 @@ class Container:
 
     def register_factory(  # noqa: PLR0913
         self,
-        factory: object,
+        factory: Callable[..., object],
         *,
         return_type: type,
         scope: Scope = Scope.SINGLETON,
@@ -222,15 +225,15 @@ class Container:
                 )
             self._register_factory_classmethods(obj, seen)
 
-        for _name, obj in inspect.getmembers(mod, inspect.isfunction):
-            if obj in seen:
+        for _name, fn in inspect.getmembers(mod, inspect.isfunction):
+            if fn in seen:
                 continue
-            meta = getattr(obj, "__uncoiled__", None)
+            meta = getattr(fn, "__uncoiled__", None)
             if meta is not None:
-                seen.add(obj)
-                return_type = meta.provides or _infer_return_type(obj)
+                seen.add(fn)
+                return_type = meta.provides or _infer_return_type(fn)
                 self.register_factory(
-                    obj,
+                    fn,
                     return_type=return_type,
                     scope=meta.scope,
                     qualifier=meta.qualifier,
@@ -386,7 +389,7 @@ class Container:
             self._instances.append((instance, node.impl, qualifier))
         call_init(instance, self._init_hooks.get(hook_key))
 
-        return instance  # ty: ignore[invalid-return-type]
+        return cast("T", instance)
 
     async def _aresolve[T](self, type_: type[T], qualifier: str | None = None) -> T:
         """Resolve a type from the container (async)."""
@@ -414,7 +417,7 @@ class Container:
             self._instances.append((instance, node.impl, qualifier))
         await async_call_init(instance, self._init_hooks.get(hook_key))
 
-        return instance  # ty: ignore[invalid-return-type]
+        return cast("T", instance)
 
     def _create_instance(self, node: ComponentNode) -> object:
         """Create an instance from a ComponentNode."""
@@ -430,7 +433,7 @@ class Container:
             self._resolve_dependency(dep, kwargs, node=node)
 
         if node.factory is not None:
-            result = node.factory(**kwargs)  # ty: ignore[call-non-callable]
+            result = node.factory(**kwargs)
             if inspect.isgenerator(result):
                 instance = next(result)
                 self._generators.append(result)
@@ -459,7 +462,7 @@ class Container:
             self._resolve_dependency(dep, kwargs, node=node)
 
         if node.factory is not None:
-            result = node.factory(**kwargs)  # ty: ignore[call-non-callable]
+            result = node.factory(**kwargs)
             if inspect.isasyncgen(result):
                 instance = await result.__anext__()
                 self._generators.append(result)
@@ -563,8 +566,8 @@ class Container:
 
     def request_context(self) -> contextlib.AbstractContextManager[None]:
         """Enter a new request scope context."""
-        scope = self._scopes[Scope.REQUEST]
-        return scope.context()  # ty: ignore[unresolved-attribute]
+        scope = cast("RequestScope", self._scopes[Scope.REQUEST])
+        return scope.context()
 
     def fork(self) -> Container:
         """Create a child container with shared registrations."""
@@ -614,7 +617,7 @@ class Container:
         for gen in reversed(self._generators):
             try:
                 with contextlib.suppress(StopIteration):
-                    next(gen)  # ty: ignore[invalid-argument-type]
+                    next(gen)  # type: ignore[arg-type]
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
 
@@ -627,7 +630,7 @@ class Container:
                         await gen.__anext__()
                 else:
                     with contextlib.suppress(StopIteration):
-                        next(gen)  # ty: ignore[invalid-argument-type]
+                        next(gen)  # type: ignore[arg-type]
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
 

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from ._errors import DependencyResolutionError, FailureKind, ResolutionFailure
 from ._inspection import DependencySpec, inspect_dependencies
 from ._types import Scope
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @dataclass
@@ -20,7 +24,7 @@ class ComponentNode:
     qualifier: str | None = None
     dependencies: list[DependencySpec] = field(default_factory=list)
     scope: Scope = Scope.SINGLETON
-    factory: object | None = None
+    factory: Callable[..., object] | None = None
 
 
 def build_graph(

--- a/src/uncoiled/_inspection.py
+++ b/src/uncoiled/_inspection.py
@@ -44,7 +44,7 @@ def inspect_dependencies(target: object) -> list[DependencySpec]:
     function signature directly.
     """
     if isinstance(target, type):
-        func = target.__init__
+        func = target.__init__  # type: ignore[misc]
     elif callable(target):
         func = target
     else:

--- a/src/uncoiled/_scope.py
+++ b/src/uncoiled/_scope.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 from ._types import Scope
 
@@ -51,7 +51,7 @@ class SingletonScope:
 
     def get[T](self, key: type[T], qualifier: str | None = None) -> T | None:
         """Return the cached instance or None."""
-        return self._instances.get((key, qualifier))  # ty: ignore[invalid-return-type]
+        return cast("T | None", self._instances.get((key, qualifier)))
 
     def put[T](self, key: type[T], instance: T, qualifier: str | None = None) -> None:
         """Cache the instance."""
@@ -119,7 +119,7 @@ class RequestScope:
         instances = self._var.get(None)
         if instances is None:
             return None
-        return instances.get((key, qualifier))  # ty: ignore[invalid-return-type]
+        return cast("T | None", instances.get((key, qualifier)))
 
     def put[T](self, key: type[T], instance: T, qualifier: str | None = None) -> None:
         """Cache the instance in the current request context."""

--- a/src/uncoiled/fastapi.py
+++ b/src/uncoiled/fastapi.py
@@ -22,6 +22,7 @@ from ._container import Container  # noqa: TC001 — used at runtime in Depends(
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Sequence
 
+    from fastapi import FastAPI
     from starlette.types import ASGIApp, Receive, Scope, Send
 
 
@@ -119,16 +120,16 @@ def uncoiled_lifespan(
     """
 
     @contextlib.asynccontextmanager
-    async def _lifespan(app: object) -> AsyncIterator[None]:
+    async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         existing: Container | None = getattr(
-            getattr(app, "state", None),
+            app.state,
             "uncoiled_container",
             None,
         )
         if existing is not None:
             yield
             return
-        app.state.uncoiled_container = container  # ty: ignore[unresolved-attribute]
+        app.state.uncoiled_container = container
         container.start()
         try:
             yield
@@ -139,7 +140,7 @@ def uncoiled_lifespan(
 
 
 def configure_container(
-    app: object,
+    app: FastAPI,
     container: Container,
     request_values: Sequence[RequestValueProvider] = (),
 ) -> None:
@@ -151,5 +152,5 @@ def configure_container(
     """
     for rv in request_values:
         container.register_request_value(rv.type_, qualifier=rv.qualifier)
-    app.state.uncoiled_container = container  # ty: ignore[unresolved-attribute]
+    app.state.uncoiled_container = container
     container.start()

--- a/uv.lock
+++ b/uv.lock
@@ -1791,6 +1791,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1837,6 +1846,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "types-pyyaml" },
     { name = "uncoiled", extra = ["fastapi", "yaml"] },
 ]
 docs = [
@@ -1849,6 +1859,7 @@ lint = [
     { name = "pyright" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "types-pyyaml" },
 ]
 mutation = [
     { name = "cosmic-ray" },
@@ -1883,6 +1894,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.15.6" },
     { name = "ty", specifier = ">=0.0.23" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "uncoiled", extras = ["fastapi"] },
     { name = "uncoiled", extras = ["yaml"] },
 ]
@@ -1896,6 +1908,7 @@ lint = [
     { name = "pyright", specifier = ">=1.1" },
     { name = "ruff", specifier = ">=0.15.6" },
     { name = "ty", specifier = ">=0.0.23" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 mutation = [
     { name = "cosmic-ray", specifier = ">=8.4.4" },


### PR DESCRIPTION
## Summary

- Tighten type annotations across the codebase so mypy and pyright pass with zero errors
- Add `types-pyyaml` stub package and remove `--ignore-missing-imports` flag
- Remove `continue-on-error: true` from mypy/pyright CI steps so regressions fail the build

## Changes

**Tighter types (no ignores needed):** `_COERCIONS` dict, `ComponentNode.factory`, `Container._generators`, `register_factory` parameter, `_resolve`/`_aresolve` return types, `request_context()` scope cast, `SingletonScope`/`RequestScope` get methods, `fastapi.py` app parameter

**Targeted ignores (inherent to design):** dynamic `__uncoiled__` attribute assignment, `__init__` introspection, `dataclasses.fields()` on generic type

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)