### PR TITLE
Gate docs build on CI success

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,10 @@
 name: Docs
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Python CI"]
     branches: ["main"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -16,6 +18,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: "actions/checkout@v6"


### PR DESCRIPTION
## Summary

- Use `workflow_run` trigger so docs only build after Python CI completes on main
- Skip the build entirely if CI failed

## Test plan

- [ ] Merge and verify docs workflow triggers after CI passes
- [ ] Verify docs workflow is skipped if CI fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)