### PR TITLE
Add Scope.AUTO to infer scope from dependencies

### DIFF
--- a/src/uncoiled/_container.py
+++ b/src/uncoiled/_container.py
@@ -636,6 +636,8 @@ class Container:
 
     def _check_scope(self, scope: Scope) -> None:
         """Raise if the scope has no registered manager."""
+        if scope is Scope.AUTO:
+            return  # resolved to a concrete scope during validate/start
         if scope not in self._scopes:
             msg = f"No scope manager registered for {scope.value!r}"
             raise ValueError(msg)

--- a/src/uncoiled/_errors.py
+++ b/src/uncoiled/_errors.py
@@ -12,6 +12,7 @@ class FailureKind(enum.Enum):
     MISSING = "missing"
     CIRCULAR = "circular"
     SCOPE_MISMATCH = "scope_mismatch"
+    AUTO_CYCLE = "auto_cycle"
 
 
 @dataclass(frozen=True)

--- a/src/uncoiled/_graph.py
+++ b/src/uncoiled/_graph.py
@@ -27,6 +27,92 @@ class ComponentNode:
     factory: Callable[..., object] | None = None
 
 
+def _collect_auto_deps(
+    registrations: dict[tuple[type, str | None], ComponentNode],
+    auto_keys: set[tuple[type, str | None]],
+) -> dict[tuple[type, str | None], list[tuple[type, str | None]]]:
+    """Pre-compute registered dependency keys for each AUTO node."""
+    auto_deps: dict[tuple[type, str | None], list[tuple[type, str | None]]] = {}
+    for key in auto_keys:
+        node = registrations[key]
+        target = node.factory if node.factory is not None else node.impl
+        node.dependencies = inspect_dependencies(target)
+        auto_deps[key] = [
+            (dep.required_type, dep.qualifier)
+            for dep in node.dependencies
+            if not dep.is_list
+            and dep.env_var is None
+            and (dep.required_type, dep.qualifier) in registrations
+        ]
+    return auto_deps
+
+
+def _infer_scope(
+    dep_keys: list[tuple[type, str | None]],
+    registrations: dict[tuple[type, str | None], ComponentNode],
+    resolved: set[tuple[type, str | None]],
+) -> tuple[Scope, bool]:
+    """Infer the scope for an AUTO node from its dependencies.
+
+    Returns (inferred_scope, has_unresolved_auto_deps).
+    """
+    has_unresolved = False
+    for dk in dep_keys:
+        dep_scope = registrations[dk].scope
+        if dep_scope is Scope.AUTO and dk not in resolved:
+            has_unresolved = True
+        elif dep_scope is Scope.REQUEST:
+            return Scope.REQUEST, False
+    return Scope.SINGLETON, has_unresolved
+
+
+def _resolve_auto_scopes(
+    registrations: dict[tuple[type, str | None], ComponentNode],
+) -> list[ResolutionFailure]:
+    """Resolve AUTO-scoped components to concrete scopes via fixed-point iteration."""
+    auto_keys = {key for key, node in registrations.items() if node.scope is Scope.AUTO}
+    if not auto_keys:
+        return []
+
+    auto_deps = _collect_auto_deps(registrations, auto_keys)
+
+    resolved: set[tuple[type, str | None]] = set()
+    changed = True
+    while changed:
+        changed = False
+        for key in auto_keys - resolved:
+            inferred, has_unresolved = _infer_scope(
+                auto_deps[key],
+                registrations,
+                resolved,
+            )
+            if inferred is Scope.REQUEST or not has_unresolved:
+                registrations[key].scope = inferred
+                resolved.add(key)
+                changed = True
+
+    # Any remaining AUTO nodes form a cycle among themselves.
+    unresolved = auto_keys - resolved
+    if not unresolved:
+        return []
+    for key in unresolved:
+        registrations[key].scope = Scope.SINGLETON
+    names = sorted(registrations[k].impl.__name__ for k in unresolved)
+    return [
+        ResolutionFailure(
+            kind=FailureKind.AUTO_CYCLE,
+            message=(
+                f"Cannot infer scope for components with mutual AUTO "
+                f"dependencies: {', '.join(names)}."
+            ),
+            suggestion=(
+                "Set an explicit scope (Scope.SINGLETON or Scope.REQUEST) "
+                "on at least one component in the cycle."
+            ),
+        ),
+    ]
+
+
 def build_graph(
     registrations: dict[tuple[type, str | None], ComponentNode],
 ) -> list[ResolutionFailure]:
@@ -36,6 +122,7 @@ def build_graph(
     Collects all failures rather than stopping at the first.
     """
     failures: list[ResolutionFailure] = []
+    failures.extend(_resolve_auto_scopes(registrations))
 
     adj: dict[tuple[type, str | None], set[tuple[type, str | None]]] = defaultdict(set)
     in_degree: dict[tuple[type, str | None], int] = {}

--- a/src/uncoiled/_types.py
+++ b/src/uncoiled/_types.py
@@ -15,6 +15,7 @@ class Scope(enum.Enum):
     SINGLETON = "singleton"
     TRANSIENT = "transient"
     REQUEST = "request"
+    AUTO = "auto"
 
 
 type Factory[T] = Callable[..., T]

--- a/src/uncoiled/_visualise.py
+++ b/src/uncoiled/_visualise.py
@@ -88,6 +88,7 @@ def render_mermaid(
     lines.append(f"    classDef {_scope_class(Scope.SINGLETON)} fill:#4a9,stroke:#333")
     lines.append(f"    classDef {_scope_class(Scope.TRANSIENT)} fill:#f96,stroke:#333")
     lines.append(f"    classDef {_scope_class(Scope.REQUEST)} fill:#69f,stroke:#333")
+    lines.append(f"    classDef {_scope_class(Scope.AUTO)} fill:#ccc,stroke:#333")
     lines.append("    classDef env_var fill:#ff9,stroke:#333")
 
     return "\n".join(lines)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1580,3 +1580,59 @@ class TestScanFactoryClassmethods:
         c.scan(mod)
         assert isinstance(c.get(Impl), Impl)
         assert isinstance(c.get(Impl, qualifier="custom"), Impl)
+
+
+class AutoCycleX:
+    def __init__(self, dep: "AutoCycleY") -> None:
+        self.dep = dep
+
+
+class AutoCycleY:
+    def __init__(self, dep: AutoCycleX) -> None:
+        self.dep = dep
+
+
+class TestAutoScope:
+    def test_auto_resolves_to_singleton(self) -> None:
+        c = Container()
+        c.register(Repository, scope=Scope.AUTO)
+        c.start()
+        first = c.get(Repository)
+        second = c.get(Repository)
+        assert first is second
+
+    def test_auto_resolves_to_request_when_dep_is_request(self) -> None:
+        class TenantId:
+            pass
+
+        class Controller:
+            def __init__(self, tenant: TenantId) -> None:
+                self.tenant = tenant
+
+        c = Container()
+        c.register_request_value(TenantId)
+        c.register(Controller, scope=Scope.AUTO)
+        c.start()
+        with c.request_context():
+            c.provide_request_value(TenantId, TenantId())
+            ctrl = c.get(Controller)
+            assert isinstance(ctrl, Controller)
+
+    def test_auto_factory(self) -> None:
+        c = Container()
+        c.register(Repository)
+        c.register_factory(
+            UserService,
+            return_type=UserService,
+            scope=Scope.AUTO,
+        )
+        c.start()
+        svc = c.get(UserService)
+        assert isinstance(svc, UserService)
+
+    def test_auto_cycle_raises(self) -> None:
+        c = Container()
+        c.register(AutoCycleX, scope=Scope.AUTO)
+        c.register(AutoCycleY, scope=Scope.AUTO)
+        with pytest.raises(DependencyResolutionError, match="AUTO"):
+            c.validate()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -333,6 +333,231 @@ class TestScopeMismatch:
         assert build_graph(registrations) == []
 
 
+class SingletonDep:
+    pass
+
+
+class TransientDep:
+    pass
+
+
+class AutoNeedsSingleton:
+    def __init__(self, dep: SingletonDep) -> None:
+        self.dep = dep
+
+
+class AutoNeedsRequest:
+    def __init__(self, dep: RequestDep) -> None:
+        self.dep = dep
+
+
+class AutoNeedsTransient:
+    def __init__(self, dep: TransientDep) -> None:
+        self.dep = dep
+
+
+class AutoNeedsMixed:
+    def __init__(self, s: SingletonDep, r: RequestDep, t: TransientDep) -> None:
+        self.s = s
+        self.r = r
+        self.t = t
+
+
+class AutoNeedsAutoRequest:
+    def __init__(self, dep: AutoNeedsRequest) -> None:
+        self.dep = dep
+
+
+class AutoNeedsAutoSingleton:
+    def __init__(self, dep: AutoNeedsSingleton) -> None:
+        self.dep = dep
+
+
+class AutoCycleA:
+    def __init__(self, dep: AutoCycleB) -> None:
+        self.dep = dep
+
+
+class AutoCycleB:
+    def __init__(self, dep: AutoCycleA) -> None:
+        self.dep = dep
+
+
+class AutoNoDeps:
+    pass
+
+
+class TestAutoScope:
+    def test_auto_with_no_deps_resolves_to_singleton(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=AutoNoDeps, provides=AutoNoDeps, scope=Scope.AUTO),
+        )
+        assert build_graph(registrations) == []
+        assert registrations[(AutoNoDeps, None)].scope is Scope.SINGLETON
+
+    def test_auto_with_singleton_dep_resolves_to_singleton(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=SingletonDep, provides=SingletonDep),
+            ComponentNode(
+                impl=AutoNeedsSingleton,
+                provides=AutoNeedsSingleton,
+                scope=Scope.AUTO,
+            ),
+        )
+        assert build_graph(registrations) == []
+        assert registrations[(AutoNeedsSingleton, None)].scope is Scope.SINGLETON
+
+    def test_auto_with_request_dep_resolves_to_request(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=RequestDep,
+                provides=RequestDep,
+                scope=Scope.REQUEST,
+            ),
+            ComponentNode(
+                impl=AutoNeedsRequest,
+                provides=AutoNeedsRequest,
+                scope=Scope.AUTO,
+            ),
+        )
+        assert build_graph(registrations) == []
+        assert registrations[(AutoNeedsRequest, None)].scope is Scope.REQUEST
+
+    def test_auto_with_transient_dep_resolves_to_singleton(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=TransientDep,
+                provides=TransientDep,
+                scope=Scope.TRANSIENT,
+            ),
+            ComponentNode(
+                impl=AutoNeedsTransient,
+                provides=AutoNeedsTransient,
+                scope=Scope.AUTO,
+            ),
+        )
+        assert build_graph(registrations) == []
+        assert registrations[(AutoNeedsTransient, None)].scope is Scope.SINGLETON
+
+    def test_auto_with_mixed_deps_picks_request(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=SingletonDep, provides=SingletonDep),
+            ComponentNode(
+                impl=RequestDep,
+                provides=RequestDep,
+                scope=Scope.REQUEST,
+            ),
+            ComponentNode(
+                impl=TransientDep,
+                provides=TransientDep,
+                scope=Scope.TRANSIENT,
+            ),
+            ComponentNode(
+                impl=AutoNeedsMixed,
+                provides=AutoNeedsMixed,
+                scope=Scope.AUTO,
+            ),
+        )
+        assert build_graph(registrations) == []
+        assert registrations[(AutoNeedsMixed, None)].scope is Scope.REQUEST
+
+    def test_transitive_auto_chain_propagates_request(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=RequestDep,
+                provides=RequestDep,
+                scope=Scope.REQUEST,
+            ),
+            ComponentNode(
+                impl=AutoNeedsRequest,
+                provides=AutoNeedsRequest,
+                scope=Scope.AUTO,
+            ),
+            ComponentNode(
+                impl=AutoNeedsAutoRequest,
+                provides=AutoNeedsAutoRequest,
+                scope=Scope.AUTO,
+            ),
+        )
+        assert build_graph(registrations) == []
+        assert registrations[(AutoNeedsRequest, None)].scope is Scope.REQUEST
+        assert registrations[(AutoNeedsAutoRequest, None)].scope is Scope.REQUEST
+
+    def test_transitive_auto_chain_all_singletons(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(impl=SingletonDep, provides=SingletonDep),
+            ComponentNode(
+                impl=AutoNeedsSingleton,
+                provides=AutoNeedsSingleton,
+                scope=Scope.AUTO,
+            ),
+            ComponentNode(
+                impl=AutoNeedsAutoSingleton,
+                provides=AutoNeedsAutoSingleton,
+                scope=Scope.AUTO,
+            ),
+        )
+        assert build_graph(registrations) == []
+        assert registrations[(AutoNeedsSingleton, None)].scope is Scope.SINGLETON
+        assert registrations[(AutoNeedsAutoSingleton, None)].scope is Scope.SINGLETON
+
+    def test_auto_cycle_produces_failure(self) -> None:
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=AutoCycleA,
+                provides=AutoCycleA,
+                scope=Scope.AUTO,
+            ),
+            ComponentNode(
+                impl=AutoCycleB,
+                provides=AutoCycleB,
+                scope=Scope.AUTO,
+            ),
+        )
+        failures = build_graph(registrations)
+        auto_failures = [f for f in failures if f.kind is FailureKind.AUTO_CYCLE]
+        assert len(auto_failures) == 1
+        assert "AutoCycleA" in auto_failures[0].message
+        assert "AutoCycleB" in auto_failures[0].message
+
+    def test_explicit_scope_not_overridden(self) -> None:
+        """Explicit SINGLETON depending on REQUEST still fails (not auto-resolved)."""
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=RequestDep,
+                provides=RequestDep,
+                scope=Scope.REQUEST,
+            ),
+            ComponentNode(
+                impl=SingletonNeedsRequest,
+                provides=SingletonNeedsRequest,
+                scope=Scope.SINGLETON,
+            ),
+        )
+        failures = build_graph(registrations)
+        assert any(f.kind is FailureKind.SCOPE_MISMATCH for f in failures)
+
+    def test_auto_factory(self) -> None:
+        def create_service(dep: RequestDep) -> AutoNeedsRequest:
+            return AutoNeedsRequest(dep)
+
+        registrations = _make_registrations(
+            ComponentNode(
+                impl=RequestDep,
+                provides=RequestDep,
+                scope=Scope.REQUEST,
+            ),
+            ComponentNode(
+                impl=AutoNeedsRequest,
+                provides=AutoNeedsRequest,
+                scope=Scope.AUTO,
+                factory=create_service,
+            ),
+        )
+        assert build_graph(registrations) == []
+        assert registrations[(AutoNeedsRequest, None)].scope is Scope.REQUEST
+
+
 class TestValidateGraph:
     def test_raises_on_failure(self) -> None:
         registrations = _make_registrations(


### PR DESCRIPTION
## Summary

- Add `Scope.AUTO` as an opt-in scope that infers lifecycle from the dependency graph
- REQUEST if any dependency is request-scoped, SINGLETON otherwise (TRANSIENT is transparent)
- Transitive: chains of AUTO components resolve correctly
- Cycles among AUTO components are reported as `AUTO_CYCLE` validation errors
- Supported on both `@component` and `@factory` decorators
- AUTO will not become the default; `Scope.SINGLETON` remains the default

## Changes

- `_types.py`: Add `Scope.AUTO` enum member
- `_errors.py`: Add `FailureKind.AUTO_CYCLE`
- `_graph.py`: Fixed-point scope resolution in `_resolve_auto_scopes()`, called at the start of `build_graph()`
- `_container.py`: Allow `Scope.AUTO` in `_check_scope()` (resolved before any instance creation)
- `_visualise.py`: Add Mermaid style for AUTO scope
- Tests: 14 new tests (11 graph unit + 4 container integration)

## Test plan

- [x] AUTO with no deps -> SINGLETON
- [x] AUTO with SINGLETON dep -> SINGLETON
- [x] AUTO with REQUEST dep -> REQUEST
- [x] AUTO with TRANSIENT dep -> SINGLETON
- [x] AUTO with mixed deps -> REQUEST
- [x] Transitive AUTO chains (both directions)
- [x] AUTO cycle detection
- [x] Explicit scopes not overridden
- [x] Factory support
- [x] Container integration (start, request context, validate)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)