### PR TITLE
Update GitHub Actions to Node 22 versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.14"
       - run: "uv sync --group docs --locked"
       - run: "uv run sphinx-build -b html docs docs/_build/html -W"
-      - uses: "actions/upload-pages-artifact@v3"
+      - uses: "actions/upload-pages-artifact@v4"
         with:
           path: docs/_build/html
 
@@ -39,4 +39,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: "actions/deploy-pages@v4"
+        uses: "actions/deploy-pages@v5"


### PR DESCRIPTION
## Summary

- Bump `upload-pages-artifact` v3 → v4 and `deploy-pages` v4 → v5
- Resolves Node v20 deprecation warnings in docs build

## Test plan

- [ ] Docs workflow runs without Node deprecation warnings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)